### PR TITLE
Refactor: improve blog article readability and mobile nav behavior

### DIFF
--- a/src/app/_components/markdown-styles.module.css
+++ b/src/app/_components/markdown-styles.module.css
@@ -1,18 +1,184 @@
 .markdown {
-  @apply text-lg leading-relaxed;
+  color: rgba(255, 255, 255, 0.9);
+  font-family: Charter, "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-size: clamp(1.08rem, 1rem + 0.28vw, 1.24rem);
+  line-height: 1.92;
 }
 
 .markdown p,
 .markdown ul,
 .markdown ol,
 .markdown blockquote {
-  @apply my-6;
+  margin: 1.35rem 0;
+}
+
+.markdown > *:first-child {
+  margin-top: 0;
+}
+
+.markdown > *:last-child {
+  margin-bottom: 0;
+}
+
+.markdown h2,
+.markdown h3,
+.markdown h4 {
+  color: #ffffff;
+  font-family: "Source Sans Pro", Helvetica, sans-serif;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
 }
 
 .markdown h2 {
-  @apply text-3xl mt-12 mb-4 leading-snug;
+  margin: 3.6rem 0 1rem;
+  font-size: clamp(2.02rem, 1.74rem + 0.98vw, 2.68rem);
 }
 
 .markdown h3 {
-  @apply text-2xl mt-8 mb-4 leading-snug;
+  margin: 2.7rem 0 0.85rem;
+  font-size: clamp(1.5rem, 1.3rem + 0.64vw, 1.92rem);
+}
+
+.markdown h4 {
+  margin: 2rem 0 0.75rem;
+  font-size: 1.24rem;
+}
+
+.markdown strong,
+.markdown b {
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.markdown em {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.markdown a {
+  color: #8cc9f0;
+  text-decoration: underline;
+  text-decoration-color: rgba(140, 201, 240, 0.45);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.14em;
+  transition:
+    color 0.2s ease,
+    text-decoration-color 0.2s ease;
+}
+
+.markdown a:hover {
+  color: #ffffff;
+  text-decoration-color: rgba(255, 255, 255, 0.55);
+}
+
+.markdown hr {
+  margin: 2.5rem auto;
+  width: min(8rem, 30%);
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.markdown ul,
+.markdown ol {
+  padding-left: 1.35rem;
+}
+
+.markdown ul {
+  list-style: disc;
+}
+
+.markdown ol {
+  list-style: decimal;
+}
+
+.markdown li {
+  margin: 0.55rem 0;
+  padding-left: 0.35rem;
+}
+
+.markdown li::marker {
+  color: rgba(140, 201, 240, 0.95);
+}
+
+.markdown blockquote {
+  padding: 1rem 1.25rem 1rem 1.4rem;
+  border-left: 3px solid rgba(140, 201, 240, 0.7);
+  border-radius: 0 1rem 1rem 0;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.markdown blockquote > *:last-child {
+  margin-bottom: 0;
+}
+
+.markdown :not(pre) > code {
+  padding: 0.12rem 0.42rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.45rem;
+  background: rgba(255, 255, 255, 0.07);
+  color: #f8fbff;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.88em;
+}
+
+.markdown pre {
+  overflow-x: auto;
+  margin: 1.8rem 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.markdown pre code {
+  display: block;
+  overflow-x: auto;
+  padding: 1rem 1.1rem;
+  border-radius: 1rem;
+  background: rgba(4, 11, 24, 0.88);
+  border: 0;
+  color: rgba(255, 255, 255, 0.92);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.92em;
+  line-height: 1.75;
+}
+
+.markdown pre code[class~="language-ruby"] {
+  color: #d9ecff;
+}
+
+.markdown img {
+  display: block;
+  width: 100%;
+  margin: 1.8rem 0;
+  border-radius: 1rem;
+}
+
+@media screen and (max-width: 736px) {
+  .markdown {
+    font-size: 1rem;
+    line-height: 1.82;
+  }
+
+  .markdown p,
+  .markdown ul,
+  .markdown ol,
+  .markdown blockquote {
+    margin: 1.15rem 0;
+  }
+
+  .markdown ul,
+  .markdown ol {
+    padding-left: 1.1rem;
+  }
+
+  .markdown pre {
+    margin: 1.5rem 0;
+  }
+
+  .markdown pre code {
+    padding: 0.9rem;
+    border-radius: 0.85rem;
+  }
 }

--- a/src/app/_components/nav.tsx
+++ b/src/app/_components/nav.tsx
@@ -5,35 +5,37 @@ import { useState, useEffect } from "react";
 export function Nav() {
   const { navLinks } = useLayoutContext();
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const [navHeight, setNavHeight] = useState(0);
+
+  const syncMainPadding = () => {
+    const navElement = document.getElementById('nav');
+    const main = document.getElementById('main');
+
+    if (navElement && main) {
+      main.style.paddingTop = `${navElement.offsetHeight}px`;
+    }
+  };
 
   useEffect(() => {
-    const navElement = document.getElementById('nav');
-    if(navElement) {
-      const height = navElement.offsetHeight;
-      setNavHeight(height);
-      const main = document.getElementById('main');
-      if (main) {
-        main.style.paddingTop = `${height}px`;
-      }
-    }
+    syncMainPadding();
+
+    const handleResize = () => syncMainPadding();
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
   }, [navLinks]);
 
   const toggleNavbar = () => {
-    const main = document.getElementById('main');
     const navElement = document.getElementById('nav');
-    if (main && navElement) {
-      if (isCollapsed) {
-        // Calculate the height of the uncollapsed navbar
-        main.style.paddingTop = `${navHeight}px`;
-      } else {
-        main.style.paddingTop = '3em';
-        // Set padding for collapsed navbar
-      }
-      navElement.classList.toggle('collapsed');
+
+    if (navElement) {
+      const nextCollapsed = !isCollapsed;
+      navElement.classList.toggle('collapsed', nextCollapsed);
+      setIsCollapsed(nextCollapsed);
+
+      requestAnimationFrame(() => {
+        syncMainPadding();
+      });
     }
-    
-    setIsCollapsed(!isCollapsed);
   };
 
   return (

--- a/src/app/_components/post-body.tsx
+++ b/src/app/_components/post-body.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export function PostBody({ content }: Props) {
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="mx-auto max-w-[68rem]">
       <div
         className={markdownStyles["markdown"]}
         dangerouslySetInnerHTML={{ __html: content }}

--- a/src/app/blog/posts/[slug]/page.tsx
+++ b/src/app/blog/posts/[slug]/page.tsx
@@ -36,7 +36,6 @@ export default async function Post(props: Params) {
             </span>
           )}
           <div className={styles.articleMeta}>
-            <p className={styles.articleEyebrow}>Engineering Notes</p>
             <p className={styles.articleDate}>
               <DateFormatter dateString={post.date} />
             </p>

--- a/src/app/blog/posts/[slug]/page.tsx
+++ b/src/app/blog/posts/[slug]/page.tsx
@@ -5,6 +5,8 @@ import markdownToHtml from "@/lib/markdownToHtml";
 
 import DateFormatter from "@/app/_components/date-formatter";
 import { LayoutUpdater } from "@/app/_components/LayoutUpdater";
+import { PostBody } from "@/app/_components/post-body";
+import styles from "./post-page.module.css";
 
 export default async function Post(props: Params) {
   const params = await props.params;
@@ -27,17 +29,21 @@ export default async function Post(props: Params) {
     >
 
       <div id="main">
-
-        <section id="content" className="main bg-opacity-70 bg-gray-800">
-          { post.coverImage && <span className="image main"><img src={post.coverImage} alt="" /></span> } 
-            <p><DateFormatter dateString={post.date} /></p>
-            <div
-              dangerouslySetInnerHTML={{ __html: content }}
-            />
+        <section id="content" className={`main ${styles.postSection}`}>
+          {post.coverImage && (
+            <span className={`image main ${styles.coverImage}`}>
+              <img src={post.coverImage} alt="" />
+            </span>
+          )}
+          <div className={styles.articleMeta}>
+            <p className={styles.articleEyebrow}>Engineering Notes</p>
+            <p className={styles.articleDate}>
+              <DateFormatter dateString={post.date} />
+            </p>
+          </div>
+          <PostBody content={content} />
         </section>
-
       </div>
-       
     </LayoutUpdater>
   );
 }

--- a/src/app/blog/posts/[slug]/post-page.module.css
+++ b/src/app/blog/posts/[slug]/post-page.module.css
@@ -31,25 +31,16 @@
   z-index: 1;
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 1rem;
   margin: 0 auto 2rem;
   padding-bottom: 1rem;
-  max-width: 56rem;
+  max-width: 68rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.articleEyebrow,
 .articleDate {
   margin: 0;
-}
-
-.articleEyebrow {
-  color: rgba(140, 201, 240, 0.95);
-  font-size: 0.82rem;
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
 }
 
 .articleDate {
@@ -60,9 +51,7 @@
 
 @media screen and (max-width: 736px) {
   .articleMeta {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 0.45rem;
+    justify-content: flex-start;
     margin-bottom: 1.6rem;
   }
 }

--- a/src/app/blog/posts/[slug]/post-page.module.css
+++ b/src/app/blog/posts/[slug]/post-page.module.css
@@ -1,0 +1,68 @@
+.postSection {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(9, 27, 49, 0.94), rgba(11, 22, 39, 0.96)),
+    linear-gradient(135deg, rgba(140, 201, 240, 0.06), rgba(95, 21, 85, 0.08));
+}
+
+.postSection::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top left, rgba(140, 201, 240, 0.1), transparent 34%),
+    radial-gradient(circle at top right, rgba(95, 21, 85, 0.16), transparent 42%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 30%);
+  pointer-events: none;
+}
+
+.coverImage {
+  position: relative;
+  z-index: 1;
+}
+
+.coverImage img {
+  filter: saturate(0.96) contrast(1.04);
+}
+
+.articleMeta {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 0 auto 2rem;
+  padding-bottom: 1rem;
+  max-width: 56rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.articleEyebrow,
+.articleDate {
+  margin: 0;
+}
+
+.articleEyebrow {
+  color: rgba(140, 201, 240, 0.95);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.articleDate {
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+@media screen and (max-width: 736px) {
+  .articleMeta {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.45rem;
+    margin-bottom: 1.6rem;
+  }
+}


### PR DESCRIPTION
## Summary
- improve blog article typography, spacing, and reading width
- move article presentation back into the existing page container instead of a nested inner card
- refine article date/header treatment to better match the updated layout
- clean up code block styling so snippets sit on a single dark surface
- fix mobile nav expansion on article pages by syncing main content offset to actual nav height

## Changes
- added article-specific post page styling for a more readable long-form layout
- increased desktop article width and slightly increased desktop body/headline scale
- improved markdown rendering styles for paragraphs, headings, lists, blockquotes, links, inline code, and code blocks
- removed the `Engineering Notes` eyebrow and kept the date-only meta row
- widened the article meta divider to match the reading column
- updated nav toggle behavior to recalculate layout after collapse/expand and on resize

## Verification
- `npm run build`