### PR TITLE
Bug: stabilize homepage smooth scrolling for hash navigation

### DIFF
--- a/src/app/hooks/useInitializeScripts.ts
+++ b/src/app/hooks/useInitializeScripts.ts
@@ -1,11 +1,53 @@
 "use client";
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
+import { useLayoutContext } from '@/app/context/LayoutContext';
 
 export function useInitializeScripts() {
   const pathname = usePathname();
+  const { navLinks } = useLayoutContext();
 
   useEffect(() => {
+    const handleHashLinkClick = (event: MouseEvent) => {
+      const target = event.target;
+
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      const anchor = target.closest('a[href^="#"]') as HTMLAnchorElement | null;
+
+      if (!anchor) {
+        return;
+      }
+
+      const href = anchor.getAttribute('href') || '';
+
+      if (href.length < 2) {
+        return;
+      }
+
+      const destination = document.querySelector(href);
+
+      if (!destination) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const nav = document.getElementById('nav');
+      const navOffset = nav ? nav.offsetHeight : 0;
+      const top = destination.getBoundingClientRect().top + window.scrollY - navOffset;
+
+      window.scrollTo({
+        top: Math.max(top, 0),
+        behavior: 'smooth',
+      });
+
+      window.history.replaceState(null, '', href);
+    };
+
     const handleRouteChange = () => {
       const $ = (window as any).jQuery;
 
@@ -26,17 +68,18 @@ export function useInitializeScripts() {
           });
 
           const $nav_a = $nav.find('a');
-          $nav_a.scrolly({
-            speed: 1000,
-            offset: function () {
-              return $nav.height();
-            },
-          });
+
+          $nav_a.off('click');
+          $nav_a.off('click.scrolly');
         }
       }
     };
-    
-    handleRouteChange()
 
-  }, [pathname]);
+    document.addEventListener('click', handleHashLinkClick, true);
+    handleRouteChange();
+
+    return () => {
+      document.removeEventListener('click', handleHashLinkClick, true);
+    };
+  }, [pathname, navLinks]);
 }


### PR DESCRIPTION
## Summary
- fix intermittent smooth-scroll failures on homepage section links
- make same-page hash navigation deterministic after React nav updates
- prevent fallback snap-to-anchor behavior caused by stale template bindings

## Changes
- added a single capture-phase handler for in-page `#hash` links in [useInitializeScripts.ts](/Users/dmitryjum/dev/dmitryjum-blog/src/app/hooks/useInitializeScripts.ts)
- compute scroll destination using the current nav height so section offsets remain correct
- re-run initialization when `navLinks` change, not just on pathname changes
- remove old jQuery click/scrolly handlers from nav links to avoid duplicate or stale scroll owners

## Root Cause
- the app mixes legacy template scroll scripts with React-driven nav content
- nav anchors can be replaced after the template scripts bind, leaving some links to fall back to native hash jumps instead of smooth scrolling