### PR TITLE
Add blog search and tag-based browsing

### DIFF
--- a/src/app/blog/blog-filters.tsx
+++ b/src/app/blog/blog-filters.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { KeyboardEvent, useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { TagLink } from "@/app/_components/tag-link";
+
+type Props = {
+  searchQuery?: string;
+  selectedTag?: string;
+  tags: string[];
+  totalPosts: number;
+};
+
+export function BlogFilters({ searchQuery, selectedTag, tags, totalPosts }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [query, setQuery] = useState(searchQuery ?? "");
+
+  useEffect(() => {
+    setQuery(searchQuery ?? "");
+  }, [searchQuery]);
+
+  function navigate(nextTag?: string, nextQuery?: string) {
+    const href = buildBlogHref(1, nextTag, nextQuery);
+    startTransition(() => {
+      router.push(href, { scroll: false });
+    });
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    navigate(selectedTag, query.trim() || undefined);
+  }
+
+  return (
+    <section className="px-4 pb-1 pt-8 md:px-8 md:pt-10">
+      <form onSubmit={handleSubmit} className="mb-5">
+        <div className="mx-auto flex max-w-xl items-stretch gap-2 md:mx-0">
+          <label className="relative block h-11 min-w-0 flex-1">
+            <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-slate-500">
+              <Search size={18} strokeWidth={2} />
+            </span>
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search by project, company, tool, or topic"
+              className="h-full w-full rounded-full border border-white/10 bg-slate-950/70 pl-11 pr-4 text-base text-white placeholder:text-slate-500 focus:border-fuchsia-300/50 focus:outline-none focus:ring-2 focus:ring-fuchsia-300/20"
+            />
+          </label>
+          <div className="flex h-11 shrink-0 items-stretch gap-2">
+            <PillAction
+              label={isPending ? "Searching" : "Search"}
+              onActivate={() => navigate(selectedTag, query.trim() || undefined)}
+              active={Boolean(query.trim())}
+              tone="search"
+              disabled={isPending}
+            />
+            {(selectedTag || searchQuery) && (
+              <PillAction
+                label="Clear"
+                onActivate={() => {
+                  setQuery("");
+                  navigate(undefined, undefined);
+                }}
+                tone="clear"
+                disabled={isPending}
+              />
+            )}
+          </div>
+        </div>
+      </form>
+
+      <div className="flex flex-wrap items-end justify-center gap-3 border-b border-white/10 pb-3 md:justify-start">
+        <TagLink href={buildBlogHref(1)} label="All" active={!selectedTag} />
+        {tags.map((tag) => (
+          <TagLink
+            key={tag}
+            href={buildBlogHref(1, tag)}
+            label={tag}
+            active={tag === selectedTag}
+          />
+        ))}
+        <span className="self-end pb-1 text-center text-sm leading-none text-slate-400 max-sm:w-full max-sm:pt-1 md:ml-auto md:text-right">
+          {totalPosts} article{totalPosts === 1 ? "" : "s"}
+          {selectedTag ? ` in ${selectedTag}` : ""}
+          {searchQuery ? ` matching "${searchQuery}"` : ""}
+        </span>
+      </div>
+    </section>
+  );
+}
+
+type PillActionProps = {
+  label: string;
+  onActivate: () => void;
+  active?: boolean;
+  tone: "search" | "clear";
+  disabled?: boolean;
+};
+
+function PillAction({ label, onActivate, active = false, tone, disabled = false }: PillActionProps) {
+  function handleKeyDown(event: KeyboardEvent<HTMLSpanElement>) {
+    if (disabled) {
+      return;
+    }
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onActivate();
+    }
+  }
+
+  return (
+    <span
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled}
+      onClick={disabled ? undefined : onActivate}
+      onKeyDown={handleKeyDown}
+      className={[
+        "inline-flex h-full cursor-pointer items-center self-stretch rounded-full border px-4 py-2 text-sm font-medium leading-none transition-[border-color,background-color,color,transform,box-shadow,opacity] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
+        disabled ? "pointer-events-none opacity-60" : "hover:-translate-y-px",
+        tone === "search"
+          ? active
+            ? "border-emerald-300/60 bg-emerald-900 text-emerald-50 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_10px_24px_rgba(5,150,105,0.22)]"
+            : "border-emerald-300/60 bg-emerald-900 text-emerald-50 shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_8px_18px_rgba(5,150,105,0.16)] hover:border-emerald-200/70 hover:bg-emerald-800"
+          : "border-rose-300/35 bg-rose-950/80 text-rose-50 hover:border-rose-200/50 hover:bg-rose-900",
+      ].join(" ")}
+    >
+      {label}
+    </span>
+  );
+}
+
+function buildBlogHref(page: number, tag?: string, query?: string) {
+  const params = new URLSearchParams();
+  params.set("page", String(page));
+  if (tag) {
+    params.set("tag", tag);
+  }
+  if (query) {
+    params.set("q", query);
+  }
+
+  return `/blog?${params.toString()}`;
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,7 +1,8 @@
 import Container from "@/app/_components/container";
 import { MoreStories } from "@/app/_components/more-stories";
 import { TagLink } from "@/app/_components/tag-link";
-import { getAllPosts, getAllTags, getPaginatedPosts, getPostsByTag } from "@/lib/api";
+import { BlogFilters } from "./blog-filters";
+import { getAllTags, getFilteredPosts, getPaginatedPosts } from "@/lib/api";
 import { LayoutUpdater } from "@/app/_components/LayoutUpdater";
 import { redirect } from "next/navigation";
 
@@ -9,6 +10,7 @@ type Params = {
   searchParams: Promise<{
     page?: string;
     tag?: string;
+    q?: string;
   }>;
 };
 
@@ -16,15 +18,16 @@ export default async function Index(props: Params) {
   const searchParams = await props.searchParams;
   const page = parseInt(searchParams.page || "1", 10);
   const selectedTag = searchParams.tag?.trim() || undefined;
+  const searchQuery = searchParams.q?.trim() || undefined;
   const limit = 8;
   const tags = getAllTags();
-  const filteredPosts = selectedTag ? getPostsByTag(selectedTag) : undefined;
-  const totalPosts = filteredPosts?.length ?? getAllPosts().length;
+  const filteredPosts = getFilteredPosts(selectedTag, searchQuery);
+  const totalPosts = filteredPosts.length;
   const totalPages = Math.max(1, Math.ceil(totalPosts / limit));
   if (page > totalPages || page < 1) {
-    redirect(buildBlogHref(1, selectedTag));
+    redirect(buildBlogHref(1, selectedTag, searchQuery));
   }
-  const allPosts = getPaginatedPosts(page, limit, selectedTag);
+  const allPosts = getPaginatedPosts(page, limit, selectedTag, searchQuery);
 
   function generatePageLinks(currentPage: number, totalPages: number) {
     const pageLinks: Array<number | string> = [];
@@ -79,30 +82,19 @@ export default async function Index(props: Params) {
     >
       <div id="main">
         <Container>
-          <section className="mb-0 px-4 pt-8 md:px-8 md:pt-10">
-            <div className="flex flex-wrap items-end justify-center gap-3 border-b border-white/10 pb-3 md:justify-start">
-              <TagLink href="/blog" label="All" active={!selectedTag} />
-              {tags.map((tag) => (
-                <TagLink
-                  key={tag}
-                  href={buildBlogHref(1, tag)}
-                  label={tag}
-                  active={tag === selectedTag}
-                />
-              ))}
-              <span className="self-end pb-1 text-center text-sm leading-none text-slate-400 max-sm:w-full max-sm:pt-1 md:ml-auto md:text-right">
-                {totalPosts} article{totalPosts === 1 ? "" : "s"}
-                {selectedTag ? ` in ${selectedTag}` : ""}
-              </span>
-            </div>
-          </section>
+          <BlogFilters
+            searchQuery={searchQuery}
+            selectedTag={selectedTag}
+            tags={tags}
+            totalPosts={totalPosts}
+          />
 
           {allPosts.length > 0 && <MoreStories posts={allPosts} />}
           {allPosts.length === 0 && (
             <section className="rounded-[1.75rem] border border-dashed border-white/15 bg-slate-950/40 px-6 py-10 text-center">
-              <p className="text-lg text-white">No posts found for this tag.</p>
+              <p className="text-lg text-white">No posts matched your current filters.</p>
               <p className="mt-2 text-sm text-slate-400">
-                Try another topic or return to all articles.
+                Try another search, pick a different tag, or return to all articles.
               </p>
               <div className="mt-5">
                 <TagLink href="/blog" label="Back to all posts" />
@@ -111,12 +103,12 @@ export default async function Index(props: Params) {
           )}
           <div className="flex justify-center px-4 pb-8 pt-2 md:px-8">
             <div className="flex flex-wrap items-center justify-center gap-3">
-              {page > 1 && <a href={buildBlogHref(page - 1, selectedTag)} className="button tiny inline-flex items-center justify-center align-middle">&#8592;</a>}
+              {page > 1 && <a href={buildBlogHref(page - 1, selectedTag, searchQuery)} className="button tiny inline-flex items-center justify-center align-middle">&#8592;</a>}
               {pageLinks.length > 1 && pageLinks.map((pageLink, index) => (
                 typeof pageLink === 'number' ? (
                   <a
                     key={index}
-                    href={buildBlogHref(pageLink, selectedTag)}
+                    href={buildBlogHref(pageLink, selectedTag, searchQuery)}
                     className={`button tiny inline-flex items-center justify-center align-middle ${pageLink === page ? 'primary' : ''}`}
                   >
                     {pageLink}
@@ -125,7 +117,7 @@ export default async function Index(props: Params) {
                   <span key={index} className="ellipsis">...</span>
                 )
               ))}
-              {page < totalPages && <a href={buildBlogHref(page + 1, selectedTag)} className="button tiny inline-flex items-center justify-center align-middle">&#8594;</a>}
+              {page < totalPages && <a href={buildBlogHref(page + 1, selectedTag, searchQuery)} className="button tiny inline-flex items-center justify-center align-middle">&#8594;</a>}
             </div>
           </div>
         </Container>
@@ -134,11 +126,14 @@ export default async function Index(props: Params) {
   );
 }
 
-function buildBlogHref(page: number, tag?: string) {
+function buildBlogHref(page: number, tag?: string, query?: string) {
   const params = new URLSearchParams();
   params.set("page", String(page));
   if (tag) {
     params.set("tag", tag);
+  }
+  if (query) {
+    params.set("q", query);
   }
 
   return `/blog?${params.toString()}`;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,8 +33,12 @@ export function getAllPosts(): Post[] {
     .sort((post1, post2) => (post1.date > post2.date ? -1 : 1));
 }
 
-export function getPaginatedPosts(page: number = 1, limit: number = 5, tag?: string): Post[] {
-  const posts = tag ? getPostsByTag(tag) : getAllPosts();
+export function getFilteredPosts(tag?: string, query?: string): Post[] {
+  return getAllPosts().filter((post) => matchesFilters(post, tag, query));
+}
+
+export function getPaginatedPosts(page: number = 1, limit: number = 5, tag?: string, query?: string): Post[] {
+  const posts = getFilteredPosts(tag, query);
   const startIndex = (page - 1) * limit;
   const endIndex = startIndex + limit;
   return posts.slice(startIndex, endIndex);
@@ -50,4 +54,36 @@ export function getAllTags(): string[] {
       getAllPosts().flatMap((post) => post.tags ?? []),
     ),
   ).sort((tagA, tagB) => tagA.localeCompare(tagB));
+}
+
+function matchesFilters(post: Post, tag?: string, query?: string) {
+  if (tag && !post.tags?.includes(tag)) {
+    return false;
+  }
+
+  if (!query) {
+    return true;
+  }
+
+  const searchTerms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (searchTerms.length === 0) {
+    return true;
+  }
+
+  const searchableText = [
+    post.title,
+    post.excerpt,
+    post.slug.replace(/-/g, " "),
+    post.tags?.join(" "),
+    post.content,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return searchTerms.every((term) => searchableText.includes(term));
 }


### PR DESCRIPTION
Implements blog discovery features across the site. Users can now browse posts by tag, search across article metadata and content, and see tags directly on article pages. This also includes UI refinements for the filter/search controls and a fix for markdown code highlighting using Shiki.