### PR TITLE
Pixel probe articles

### DIFF
--- a/_posts/detecting-gtm-network-vs-html.md
+++ b/_posts/detecting-gtm-network-vs-html.md
@@ -1,0 +1,41 @@
+---
+title: "Detecting Google Tag Manager (and why network requests aren't enough)"
+excerpt: "Building Pixel Probe, I thought detecting Google Tag Manager would be straightforward. Intercept the network requests, find the GTM ones, and call it a day. But here is why that doesn't work reliably."
+date: "2026-03-20T12:00:00.000Z"
+author:
+  name: Dmitry Jum
+  picture: "stellar/images/intro_shot.jpg"
+ogImage:
+  url: 
+tags: ["nextjs", "puppeteer", "web-scraping", "analytics"]
+---
+
+Building Pixel Probe, I thought detecting Google Tag Manager would be straightforward. Intercept the network requests, find the GTM ones, and call it a day. 
+
+That's just how it works, right?
+
+Not quite. I built [Pixel Probe](https://github.com/dmitryjum/pixel-probe) to analyze websites, detect GTM implementations, and identify custom domain analytics requests. It runs on Next.js, using a headless Chromium instance to inspect outgoing traffic. 
+
+At first, I relied purely on Puppeteer. The server would spin up, navigate to the URL, and watch the network tab. If `gtm.js` fired, we had a match.
+
+But then the edge cases started rolling in.
+
+Sometimes, the network request never fires. Maybe the site was slow. Maybe the headless browser triggered bot protection. Or maybe a built-in ad blocker stopped the tracking script before it could even try to load. The code was there in the HTML, but my network-based detection was coming up empty.
+
+So I added a fallback. 
+
+Instead of just watching the wire, I started parsing the DOM. If the network request failed to catch it, Pixel Probe uses Cheerio to inspect the raw HTML source. It looks for the actual GTM script tags embedded in the page. 
+
+It's a simple change, but an important one. Analytics aren't always about what successfully loads—sometimes they're about what the site *tried* to load. 
+
+I also had to set up some regular user agents to bypass basic bot protection. Headless browsers are notoriously easy to spot. Passing a standard user string helps the initial page load successfully more often.
+
+Between the active network monitoring and the static HTML analysis, the detection rate improved significantly. 
+
+It takes a bit more work, but combining both approaches gives a resilient detection mechanism. Pretty cool.
+
+What about you? Have you had to build reliable web scrapers lately?
+
+---
+
+The full source for this project is on GitHub: [github.com/dmitryjum/pixel-probe](https://github.com/dmitryjum/pixel-probe)

--- a/_posts/detecting-gtm-network-vs-html.md
+++ b/_posts/detecting-gtm-network-vs-html.md
@@ -1,41 +1,88 @@
 ---
-title: "Detecting Google Tag Manager (and why network requests aren't enough)"
-excerpt: "Building Pixel Probe, I thought detecting Google Tag Manager would be straightforward. Intercept the network requests, find the GTM ones, and call it a day. But here is why that doesn't work reliably."
-date: "2026-03-20T12:00:00.000Z"
+title: "Detecting Google Tag Manager: network traffic alone was not enough"
+excerpt: "Pixel Probe started as a network inspector. It got much more reliable once I separated code that exists on the page from behavior I could actually observe."
+date: "2025-10-06T12:00:00.000Z"
 author:
   name: Dmitry Jum
   picture: "stellar/images/intro_shot.jpg"
 ogImage:
-  url: 
-tags: ["nextjs", "puppeteer", "web-scraping", "analytics"]
+  url:
+tags: ["pixel-probe", "nextjs", "puppeteer", "web-scraping", "analytics"]
 ---
 
-Building Pixel Probe, I thought detecting Google Tag Manager would be straightforward. Intercept the network requests, find the GTM ones, and call it a day. 
+When I started Pixel Probe, I thought GTM detection would be the easy part.
 
-That's just how it works, right?
+Open the site in Puppeteer. Watch the requests. If `googletagmanager.com` or `google-analytics.com` shows up, mark it as tracked. If `/g/collect` shows up on a custom domain, mark it as obfuscated.
 
-Not quite. I built [Pixel Probe](https://github.com/dmitryjum/pixel-probe) to analyze websites, detect GTM implementations, and identify custom domain analytics requests. It runs on Next.js, using a headless Chromium instance to inspect outgoing traffic. 
+That works on clean demo sites.
 
-At first, I relied purely on Puppeteer. The server would spin up, navigate to the URL, and watch the network tab. If `gtm.js` fired, we had a match.
+It doesn't hold up nearly as well on the real web.
 
-But then the edge cases started rolling in.
+## What the network tab doesn't tell you
 
-Sometimes, the network request never fires. Maybe the site was slow. Maybe the headless browser triggered bot protection. Or maybe a built-in ad blocker stopped the tracking script before it could even try to load. The code was there in the HTML, but my network-based detection was coming up empty.
+A missing request doesn't mean the tracking code isn't there.
 
-So I added a fallback. 
+Sometimes the page is slow. Sometimes the headless browser gets treated differently. Sometimes consent logic blocks the request. Sometimes the code is present in the HTML but never fires during the browser session you captured.
 
-Instead of just watching the wire, I started parsing the DOM. If the network request failed to catch it, Pixel Probe uses Cheerio to inspect the raw HTML source. It looks for the actual GTM script tags embedded in the page. 
+That problem shows up pretty clearly in the repo history. The early route was almost entirely request-driven. Then a later pass added a fallback that fetches the page HTML separately and inspects script contents with Cheerio.
 
-It's a simple change, but an important one. Analytics aren't always about what successfully loads—sometimes they're about what the site *tried* to load. 
+```ts
+const html = await fetch(sanitizedUrl).then((res) => res.text());
+const $ = cheerio.load(html);
 
-I also had to set up some regular user agents to bypass basic bot protection. Headless browsers are notoriously easy to spot. Passing a standard user string helps the initial page load successfully more often.
+const gtmDetectedInHtml = $("script").filter((_, el) => {
+  const scriptContent = $(el).html() || "";
+  return ["dataLayer", "analytics", "gtag"].some((keyword) =>
+    scriptContent.includes(keyword)
+  );
+}).length > 0;
+```
 
-Between the active network monitoring and the static HTML analysis, the detection rate improved significantly. 
+The result is simple:
 
-It takes a bit more work, but combining both approaches gives a resilient detection mechanism. Pretty cool.
+```ts
+const hasGTM = gtmRequests.length > 0 || gtmDetectedInHtml;
+```
 
-What about you? Have you had to build reliable web scrapers lately?
+That line fixed more than a bug. It fixed the model.
 
----
+## Present versus observed
 
-The full source for this project is on GitHub: [github.com/dmitryjum/pixel-probe](https://github.com/dmitryjum/pixel-probe)
+This is the distinction that matters:
+
+- tracking code can be *present* in the source
+- tracking behavior can be *observed* at runtime
+
+Those are not the same thing.
+
+If you collapse them into a single yes-or-no answer, your detector ends up lying to you. It reports "nothing found" when the honest answer is "the code is there, but I didn't observe it execute."
+
+Once I separated those states, the output got better immediately.
+
+## Why the fallback happens outside Puppeteer
+
+I like that the HTML pass doesn't depend on the browser session succeeding.
+
+The browser is the fragile part of the pipeline. It's heavier. It's easier to fingerprint. It's the piece most likely to fail in a serverless environment. A plain `fetch()` and a Cheerio parse are cheap by comparison.
+
+So the fallback isn't just a second detection technique. It's also the more stable one.
+
+That's why this pattern works well outside analytics too. If you're building any kind of auditing tool, don't force everything through the most expensive runtime step.
+
+## It also changed the user-facing message
+
+After that change, the route stopped pretending every failure mode meant the same thing.
+
+If runtime requests are captured, the tool says so. If only the HTML signal is present, it says that too. If neither is found, it tells the user the site may be preventing detection.
+
+That's a better product decision than forcing certainty where there isn't any.
+
+## The broader lesson
+
+I built this for a marketer-facing use case, but the lesson is more general.
+
+If you're scraping, auditing, or detecting anything on the web, don't treat the network tab as ground truth. Treat it as one source of truth.
+
+The source code matters too.
+
+And when the two disagree, that's usually where the interesting bugs are.

--- a/_posts/hosting-chromium-on-vercel.md
+++ b/_posts/hosting-chromium-on-vercel.md
@@ -1,0 +1,37 @@
+---
+title: "Hosting Chromium on Vercel"
+excerpt: "Serverless functions are great until you need to run a browser in them. The deployment limits will stop you before you even start. Here's a custom lightweight binary approach."
+date: "2026-03-20T12:00:00.000Z"
+author:
+  name: Dmitry Jum
+  picture: "stellar/images/intro_shot.jpg"
+ogImage:
+  url: 
+tags: ["vercel", "nextjs", "puppeteer", "serverless"]
+---
+
+Serverless functions are great until you need to run a browser in them.
+
+[Pixel Probe](https://github.com/dmitryjum/pixel-probe) needs to load websites and intercept their network requests. To do that, it uses Puppeteer. But you can't just install standard Puppeteer on Vercel. It's too big. The deployment limits will stop you before you even start.
+
+I needed a lightweight option. 
+
+Instead of regular Puppeteer, I used `puppeteer-core`. It doesn't download Chromium by default. That leaves it up to you to provide the binary. 
+
+For a while, the standard approach was using `chrome-aws-lambda` or similar packages, but maintaining those across different Node versions gets tricky.
+
+I ended up hosting the binary myself. 
+
+I grabbed a minimal Chromium build specifically for Amazon Linux 2 (which is what Vercel runs under the hood). I compressed it using Brotli to keep the size down—you'll see files like `chromium.br` and `swiftshader.tar.br` in the initial attempts. Eventually, I put the complete tarball in an S3 bucket and pointed a `CHROMIUM_URL` environment variable to it.
+
+When the Next.js API route spins up, it checks if it's in production. If it is, it pulls that binary, unpacks it, and launches the browser. 
+
+Locally, `puppeteer` just works with its bundled browser. In production, we run the custom lightweight build. 
+
+It handles the deployment limits while still giving Pixel Probe the full browser capabilities it needs to analyze network traffic. It's a bit of a dance to get it configured right. 
+
+But once you do? It's good fun seeing a headless browser spin up on a serverless function.
+
+---
+
+The full source for this project is on GitHub: [github.com/dmitryjum/pixel-probe](https://github.com/dmitryjum/pixel-probe)

--- a/_posts/hosting-chromium-on-vercel.md
+++ b/_posts/hosting-chromium-on-vercel.md
@@ -1,37 +1,100 @@
 ---
-title: "Hosting Chromium on Vercel"
-excerpt: "Serverless functions are great until you need to run a browser in them. The deployment limits will stop you before you even start. Here's a custom lightweight binary approach."
-date: "2026-03-20T12:00:00.000Z"
+title: "Hosting Chromium on Vercel without pretending it's simple"
+excerpt: "Pixel Probe needed a real browser in a serverless route. The final setup looks tidy, but the path there went through a few dead ends first."
+date: "2025-10-07T12:00:00.000Z"
 author:
   name: Dmitry Jum
   picture: "stellar/images/intro_shot.jpg"
 ogImage:
-  url: 
-tags: ["vercel", "nextjs", "puppeteer", "serverless"]
+  url:
+tags: ["pixel-probe", "vercel", "nextjs", "puppeteer", "serverless"]
 ---
 
-Serverless functions are great until you need to run a browser in them.
+Pixel Probe only works if it can behave like a browser.
 
-[Pixel Probe](https://github.com/dmitryjum/pixel-probe) needs to load websites and intercept their network requests. To do that, it uses Puppeteer. But you can't just install standard Puppeteer on Vercel. It's too big. The deployment limits will stop you before you even start.
+It has to open a site, wait for the page to run, and inspect the actual requests leaving the browser. Parsing HTML helps, but it doesn't replace runtime traffic. The browser isn't a nice-to-have in this app. It's the whole point.
 
-I needed a lightweight option. 
+That was fine locally.
 
-Instead of regular Puppeteer, I used `puppeteer-core`. It doesn't download Chromium by default. That leaves it up to you to provide the binary. 
+It was not fine on Vercel.
 
-For a while, the standard approach was using `chrome-aws-lambda` or similar packages, but maintaining those across different Node versions gets tricky.
+## I started with the obvious setup
 
-I ended up hosting the binary myself. 
+My first pass used Puppeteer the normal way. That's the easy path when you're building locally because Chromium comes bundled and everything feels straightforward.
 
-I grabbed a minimal Chromium build specifically for Amazon Linux 2 (which is what Vercel runs under the hood). I compressed it using Brotli to keep the size down—you'll see files like `chromium.br` and `swiftshader.tar.br` in the initial attempts. Eventually, I put the complete tarball in an S3 bucket and pointed a `CHROMIUM_URL` environment variable to it.
+Then I tried to deploy it.
 
-When the Next.js API route spins up, it checks if it's in production. If it is, it pulls that binary, unpacks it, and launches the browser. 
+That's when the whole thing stopped being a scraping problem and turned into a packaging problem. Vercel will happily run your code right up until the moment you need a full browser inside a serverless function.
 
-Locally, `puppeteer` just works with its bundled browser. In production, we run the custom lightweight build. 
+I tried a few directions before settling on the one that stuck. I looked at Playwright. I looked at remote-browser options. I tried different ways of hosting or packaging Chromium. None of that felt clean.
 
-It handles the deployment limits while still giving Pixel Probe the full browser capabilities it needs to analyze network traffic. It's a bit of a dance to get it configured right. 
+The annoying part was that the product requirement never changed. I still needed a real browser because I needed the network requests, not just the page source.
 
-But once you do? It's good fun seeing a headless browser spin up on a serverless function.
+## The setup that finally worked
 
----
+What I ended up with was a split setup:
 
-The full source for this project is on GitHub: [github.com/dmitryjum/pixel-probe](https://github.com/dmitryjum/pixel-probe)
+- locally, use `puppeteer`
+- in production, use `puppeteer-core`
+- provide Chromium explicitly with `@sparticuz/chromium-min`
+
+That split is still in the API route:
+
+```ts
+if (process.env.NODE_ENV === "production") {
+  browser = await puppeteerCore.launch({
+    defaultViewport: chromium.defaultViewport,
+    executablePath: await chromium.executablePath(chromiumPath),
+    args: chromium.args,
+    headless: chromium.headless
+  });
+} else {
+  browser = await puppeteer.launch({
+    headless: true,
+    args: ["--no-sandbox", "--disable-setuid-sandbox"]
+  });
+}
+```
+
+Once I got there, the architecture felt obvious.
+
+Before that, it didn't.
+
+The reason this split matters is more concrete than "this one felt better." Plain `puppeteer` is convenient locally because it downloads a compatible browser for you. That's exactly what I wanted on my machine, where install size wasn't the problem and I just needed things to run.
+
+On Vercel, that convenience becomes baggage. Vercel's current function limits document says the function size limit is 250 MB uncompressed, and that size includes imported libraries and bundled files. So pulling in a package that wants to bring a browser along with it is a very different decision in production than it is locally.
+
+That's why `puppeteer-core` made sense. It gives me the control code without bundling Chromium. And `@sparticuz/chromium-min` exists for this exact class of problem: its README says the `-min` package does not include the Chromium Brotli files and is useful when your host has file size limits. That let me keep the browser setup explicit instead of letting one dependency quietly drag the whole deployment in the wrong direction.
+
+## The hard part wasn't the code
+
+The final code is short. The hard part was figuring out which responsibilities belonged to which environment.
+
+On my machine, bundled Chromium is a feature.
+On Vercel, bundled Chromium is baggage.
+
+That sounds obvious in hindsight, but I had to feel the pain first before the shape of the solution became clear. `puppeteer-core` only made sense once I accepted that production needed to be treated as a different runtime, not as a smaller version of local development.
+
+I also ended up keeping browser artifacts around explicitly instead of pretending the platform would sort that part out for me. That was the real shift. Stop expecting the default install story to carry production, and bring the browser yourself.
+
+## I thought about removing the browser
+
+There was a simpler option: drop the runtime inspection and just analyze HTML.
+
+That would have made deployment easier.
+
+It also would have made Pixel Probe less honest.
+
+The whole point of the app is that it can say, "this page emitted these requests." If I remove the browser, then I can only say, "this page contains code that looks like tracking." That's a different product, and a weaker one.
+
+So I kept the browser and solved the deployment problem instead.
+
+## What I took from it
+
+If you need Chromium on Vercel, don't treat it like a normal dependency and hope the platform figures it out for you.
+
+Treat local and production as different environments with different needs. Use the full browser locally when it's convenient. Use `puppeteer-core` in production when you need control. Bring the executable yourself.
+
+That was the part that took me too long to understand.
+
+But once it clicked, the rest fell into place.

--- a/_posts/teaching-a-scraper-what-not-to-load.md
+++ b/_posts/teaching-a-scraper-what-not-to-load.md
@@ -1,0 +1,159 @@
+---
+title: "How I tried to teach a scraper what not to load"
+excerpt: "Pixel Probe got faster once I started aborting the right requests. Then I tried to make that blocklist learn on its own."
+date: "2025-10-09T12:00:00.000Z"
+author:
+  name: Dmitry Jum
+  picture: "stellar/images/intro_shot.jpg"
+ogImage:
+  url:
+tags: ["pixel-probe", "puppeteer", "nextjs", "prisma", "openai"]
+---
+
+Scrapers are funny.
+
+You spend a bunch of time trying to load a page, then you realize the real trick is not loading most of it.
+
+That happened to me with [Pixel Probe](https://github.com/dmitryjum/pixel-probe). The app uses Puppeteer to inspect outgoing requests and figure out whether a site is running Google Tag Manager directly or hiding analytics behind a custom domain. For that to work, the browser has to get far enough into the page lifecycle to actually emit the requests I care about.
+
+Images, fonts, media players, ad scripts, and random WordPress junk don't help with that. They just burn time.
+
+So the first optimization was the obvious one: start aborting requests I don't need.
+
+## The first pass was blunt, and that was fine
+
+Before I got fancy, I just hardcoded the things that kept getting in the way.
+
+Some of that was resource type based:
+
+```ts
+const blockedResourcTypes = [
+  "image",
+  "stylesheet",
+  "font",
+  "media",
+  "other"
+];
+```
+
+Some of it was domain and path based:
+
+```ts
+if (
+  blockedResourcTypes.includes(resourceType) ||
+  blockedDomains.some((domain) => requestUrl.includes(domain)) ||
+  blockedPaths.some((path) => requestUrl.includes(path))
+) {
+  req.abort();
+  return;
+}
+```
+
+That lived right inside the request interception flow. No clever architecture. Just a list of things I knew weren't helping the page reach the analytics requests I actually cared about.
+
+And it worked.
+
+This is one of those cases where a blunt tool is still a good tool. If the goal is to catch GTM or GA requests before a timeout window closes, blocking `image`, `font`, and `media` requests is not subtle, but it is effective.
+
+## Then I had the more interesting idea
+
+The hardcoded list was useful, but it had an obvious ceiling. Every new site came with new junk. I could keep growing the blocklist by hand, or I could try to teach the app what not to load.
+
+That's where the `block-useless-urls-learning` branch came from.
+
+The first change was to log every outgoing request and replace the hardcoded domain/path lists with values loaded from the database:
+
+```ts
+const loggedRequests: string[] = [];
+const blockedValues = await BlockedResources.getBlockedValues();
+
+if (
+  blockedResourcTypes.includes(resourceType) ||
+  blockedValues.some((value) => requestUrl.includes(value))
+) {
+  req.abort();
+  return;
+}
+```
+
+The backing store was tiny:
+
+```prisma
+model BlockedResource {
+  id        Int      @id @default(autoincrement())
+  value     String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+```
+
+That was the whole trick. Keep a list of previously learned values, use it on the next run, and make the scraper a little more opinionated over time.
+
+Pretty cool.
+
+## The OpenAI pass was the experimental part
+
+After a run completed, I sent the recorded requests to OpenAI and asked it to suggest domains or paths that could be blocked safely on future runs:
+
+```ts
+const OpenAIResponseSchema = z.object({
+  values: z.array(z.string()),
+});
+```
+
+The prompt was plain on purpose:
+
+```ts
+const prompt = `Analyze the following list of outgoing requests and suggest
+ domains or paths that can be safely blocked
+ without breaking the page functionality in order to make sure that the page fully loads Google Analytics or Google Tag Manager
+ scripts and makes those requests. As an example: we're trying to track the requests to following domains: ${gtmDomains.join(", ")}
+ and we want to make sure the page will load and make requests to those domains.
+ Return the result as an array of strings according to the submitted schema.\nRequests:\n${loggedRequests.join("\n")}`;
+```
+
+Then the request itself looked like this:
+
+```ts
+const { object } = await generateObject({
+  model: openai.responses("gpt-4o"),
+  prompt,
+  schema: OpenAIResponseSchema,
+});
+
+await BlockedResources.addBlockedValues(object.values);
+```
+
+The idea was simple.
+
+If the page made fifty requests and only two of them mattered to my detector, maybe the model could spot the repeat offenders and hand me back a shortlist of junk I could skip next time. Over enough runs, the scraper would stop wasting time on things that were never useful in the first place.
+
+That's the part I liked most. It turns performance tuning into a feedback loop instead of a pile of one-off exceptions.
+
+## Why I didn't ship it
+
+My client didn't need it badly enough.
+
+The current version was already fast enough for the actual workload, and the learned version introduced a new cost layer because every run now had an LLM call hanging off the end of it. That's an easy trade to justify in a research project. It's a worse trade when the existing product is already doing the job.
+
+There was also a trust problem.
+
+Hardcoded blocking is dumb, but predictable. A learned blocklist is more interesting, but it needs guardrails. If a model decides some request pattern looks useless and it's wrong, then I don't just lose performance. I risk losing the exact signal the product exists to find.
+
+So I left the idea on the branch.
+
+I still think the direction is good. I just think it needed a tighter reason to exist.
+
+## What I took from it
+
+The part that shipped taught me something simple: most scraping speed problems are really prioritization problems. You don't need the whole page. You need the tiny slice of the page that produces the signal you're after.
+
+The part that didn't ship taught me something else: not every clever optimization deserves to become product behavior.
+
+Sometimes the hand-tuned blocklist is enough.
+
+And sometimes that's the better engineering decision.
+
+---
+
+The full source for this project is on GitHub: [github.com/dmitryjum/pixel-probe](https://github.com/dmitryjum/pixel-probe)

--- a/_posts/unmasking-obfuscated-analytics.md
+++ b/_posts/unmasking-obfuscated-analytics.md
@@ -1,0 +1,31 @@
+---
+title: "Unmasking obfuscated analytics"
+excerpt: "How tracking platforms bypass ad-blockers by routing through first-party subdomains, and how Pixel Probe identifies these hidden streams."
+date: "2026-03-20T12:00:00.000Z"
+author:
+  name: Dmitry Jum
+  picture: "stellar/images/intro_shot.jpg"
+ogImage:
+  url: 
+tags: ["analytics", "puppeteer", "nextjs", "web-scraping"]
+---
+
+Ad-blockers are better than ever at stopping third-party tracking scripts. If a browser sees a request to `google-analytics.com` or `facebook.com/tr`, it blocks it instantly. 
+
+But tracking platforms adapted. They started hiding.
+
+When building [Pixel Probe](https://github.com/dmitryjum/pixel-probe), I wanted to detect not just the obvious Google Tag Manager setups, but the obfuscated ones too. These are the custom domain analytics setups—where tracking requests are routed through a first-party subdomain (like `metrics.yourdomain.com`) to bypass standard blocklists.
+
+Detecting these requests is trickier than matching a simple list of known tracking domains.
+
+To find them, Pixel Probe uses Puppeteer to intercept all outbound network requests as the page loads. Instead of just looking at the domain, it parses the request URLs and query parameters. 
+
+Most tracking payloads have a signature. Even if the domain is custom, the structure of the data often gives it away. It might be a specific query parameter combination, or a known base64-encoded payload format indicating a tracking event. By inspecting the shape of the request rather than just its destination, we can surface these hidden streams.
+
+It's a cat-and-mouse game. Trackers try to blend in with normal application traffic, and tools like Pixel Probe look for the behavioral patterns that give them away.
+
+But seeing those hidden requests pop up in the analysis dashboard? That's the best part. 
+
+---
+
+The full source for this project is on GitHub: [github.com/dmitryjum/pixel-probe](https://github.com/dmitryjum/pixel-probe)

--- a/_posts/unmasking-obfuscated-analytics.md
+++ b/_posts/unmasking-obfuscated-analytics.md
@@ -1,31 +1,89 @@
 ---
 title: "Unmasking obfuscated analytics"
-excerpt: "How tracking platforms bypass ad-blockers by routing through first-party subdomains, and how Pixel Probe identifies these hidden streams."
-date: "2026-03-20T12:00:00.000Z"
+excerpt: "How I built Pixel Probe to catch first-party analytics requests that still carry Google Analytics payloads."
+date: "2025-10-08T12:00:00.000Z"
 author:
   name: Dmitry Jum
   picture: "stellar/images/intro_shot.jpg"
 ogImage:
-  url: 
-tags: ["analytics", "puppeteer", "nextjs", "web-scraping"]
+  url:
+tags: ["pixel-probe", "analytics", "puppeteer", "nextjs", "web-scraping"]
 ---
 
-Ad-blockers are better than ever at stopping third-party tracking scripts. If a browser sees a request to `google-analytics.com` or `facebook.com/tr`, it blocks it instantly. 
+A client of mine sells server-side Google Tag Manager setups to marketers.
 
-But tracking platforms adapted. They started hiding.
+The pitch is clean: send analytics traffic through a custom subdomain, point it at a GTM server container, and now the request looks first-party instead of obviously going to Google. For a marketer, that's a product. For someone inspecting a site, it's a disguise.
 
-When building [Pixel Probe](https://github.com/dmitryjum/pixel-probe), I wanted to detect not just the obvious Google Tag Manager setups, but the obfuscated ones too. These are the custom domain analytics setups—where tracking requests are routed through a first-party subdomain (like `metrics.yourdomain.com`) to bypass standard blocklists.
+That's why I built Pixel Probe.
 
-Detecting these requests is trickier than matching a simple list of known tracking domains.
+The product question was narrow on purpose: can I tell when a site is still sending Google Analytics data, even when the hostname no longer says `google-analytics.com`?
 
-To find them, Pixel Probe uses Puppeteer to intercept all outbound network requests as the page loads. Instead of just looking at the domain, it parses the request URLs and query parameters. 
+Here's the thing: once the endpoint moves behind `metrics.example.com`, simple domain matching stops being useful. You need to look at the request itself.
 
-Most tracking payloads have a signature. Even if the domain is custom, the structure of the data often gives it away. It might be a specific query parameter combination, or a known base64-encoded payload format indicating a tracking event. By inspecting the shape of the request rather than just its destination, we can surface these hidden streams.
+## What still gives it away
 
-It's a cat-and-mouse game. Trackers try to blend in with normal application traffic, and tools like Pixel Probe look for the behavioral patterns that give them away.
+In Pixel Probe, the main heuristic is simple. Known Google domains count as direct hits. Everything else gets checked for GA-style request shapes, especially `/g/collect`.
 
-But seeing those hidden requests pop up in the analysis dashboard? That's the best part. 
+```ts
+const isGtmRequest = gtmDomains.some((domain) => requestUrl.includes(domain));
 
----
+if (isGtmRequest) gtmRequests.push(requestUrl);
+if (!isGtmRequest && requestUrl.includes('/g/collect')) {
+  obfuscatedRequests.push(requestUrl);
+}
+```
 
-The full source for this project is on GitHub: [github.com/dmitryjum/pixel-probe](https://github.com/dmitryjum/pixel-probe)
+That logic lives in the interception flow in `src/app/api/check-tracking/route.ts`. The important part isn't the exact string check. It's the mindset.
+
+I'm not trying to maintain a giant blacklist of suspicious hosts. I'm checking whether the request still looks like Google Analytics after someone routed it through a first-party domain.
+
+That's a better fit for this kind of tool.
+
+## Why a browser matters here
+
+The first version of Pixel Probe only inspected HTML. That can tell you whether a page contains GTM code, but it can't tell you where the data actually goes after the page runs.
+
+So the route opens a browser, intercepts requests, and records the outgoing URLs while the page loads:
+
+```ts
+await page.setRequestInterception(true);
+
+page.on("request", (req) => {
+  const requestUrl = req.url();
+  const resourceType = req.resourceType();
+  loggedRequests.push(requestUrl);
+
+  if (blockedResourcTypes.includes(resourceType)) {
+    req.abort();
+    return;
+  }
+
+  req.continue();
+});
+```
+
+That's the core of the app. The browser isn't there for theater. It's there because the wire is the evidence.
+
+## Why the scope stays narrow
+
+Pixel Probe doesn't try to detect every tracking platform on earth. It doesn't need to. It exists for a specific family of setups: GTM or GA implementations that are made less obvious by pushing collection behind a custom domain.
+
+That focus helps.
+
+A vague "tracker detector" is easy to talk about and hard to trust. A detector that says, "this request still looks like GA4, even though it doesn't go to a Google hostname anymore" is much more concrete.
+
+That's what made the project useful to the client. His customers weren't asking for a privacy scanner. They wanted a way to check whether another business was using the same kind of setup.
+
+## The part I like most
+
+I like projects where the business story and the implementation story are different views of the same thing.
+
+The marketer says "first-party tracking."
+The engineer says "proxy the analytics endpoint."
+The browser says "here are the actual requests."
+
+Pixel Probe just lines those up.
+
+Load the page. Watch the requests. Flag the ones that still look like Google Analytics after someone tried to make them blend in.
+
+Pretty cool.


### PR DESCRIPTION
## Summary

This PR adds a set of blog posts about building `pixel-probe`, a Next.js tool I built to detect Google Tag Manager setups and custom-domain analytics requests.

The posts cover both the product idea and the implementation details behind it, with a focus on the engineering tradeoffs that came up while building and deploying it.

## Added posts

- `Detecting Google Tag Manager: network traffic alone was not enough`
- `Hosting Chromium on Vercel without pretending it's simple`
- `Unmasking obfuscated analytics`
- `How I tried to teach a scraper what not to load`

## What these posts cover

- why network-request inspection alone was not enough for GTM detection
- why I added an HTML fallback with Cheerio
- how Pixel Probe detects custom-domain analytics requests
- why running Chromium on Vercel required a different production setup
- how blocking unnecessary requests sped up Puppeteer runs
- an abandoned experiment to learn future blocked URLs with Prisma and OpenAI

## Notes

- posts were rewritten to better match the existing first-person technical writing style
- each article includes `pixel-probe` as a tag for easier grouping on the blog
- commits were dated to match the article metadata dates