### PR TITLE
refine blog archive layout and excerpt behavior

### DIFF
--- a/src/app/_components/more-stories.tsx
+++ b/src/app/_components/more-stories.tsx
@@ -8,7 +8,7 @@ type Props = {
 export function MoreStories({ posts }: Props) {
   return (
     <section>
-      <div className="grid grid-cols-1 gap-y-6 mb-3 py-6 md:px-8">
+      <div className="mb-3 grid grid-cols-1 gap-6 py-6 md:px-8 lg:grid-cols-2">
         {posts.map((post) => (
           <PostPreview
             key={post.slug}

--- a/src/app/_components/post-preview.tsx
+++ b/src/app/_components/post-preview.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
 import { type Author } from "@/interfaces/author";
 import Link from "next/link";
 import CoverImage from "./cover-image";
@@ -22,6 +25,39 @@ export function PostPreview({
   slug,
   tags = [],
 }: Props) {
+  const [isExcerptExpanded, setIsExcerptExpanded] = useState(false);
+  const [isExcerptOverflowing, setIsExcerptOverflowing] = useState(false);
+  const excerptRef = useRef<HTMLParagraphElement>(null);
+
+  useEffect(() => {
+    const element = excerptRef.current;
+    if (!element) {
+      return;
+    }
+
+    const measureOverflow = () => {
+      const computedStyle = window.getComputedStyle(element);
+      const lineHeight = parseFloat(computedStyle.lineHeight);
+
+      if (!lineHeight) {
+        setIsExcerptOverflowing(false);
+        return;
+      }
+
+      const maxHeight = lineHeight * 2;
+      setIsExcerptOverflowing(element.scrollHeight - 1 > maxHeight);
+    };
+
+    measureOverflow();
+
+    const resizeObserver = new ResizeObserver(measureOverflow);
+    resizeObserver.observe(element);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [excerpt]);
+
   return (
     <article className="rounded-2xl border border-white/10 bg-slate-950/50 px-5 py-5 shadow-[0_18px_50px_rgba(2,6,23,0.28)] backdrop-blur-sm sm:px-6">
       {coverImage && <div className="mb-5">
@@ -46,7 +82,42 @@ export function PostPreview({
           ))}
         </div>
       )}
-      <p className="mb-4 text-base leading-relaxed text-slate-100/90 line-clamp-3">{excerpt}</p>
+      <div className="relative">
+        <p
+          ref={excerptRef}
+          className={[
+            "mb-1 text-base leading-relaxed text-slate-100/90",
+            isExcerptExpanded ? "" : "line-clamp-2",
+            isExcerptOverflowing && !isExcerptExpanded ? "pr-14" : "",
+          ].join(" ")}
+        >
+          {excerpt}
+        </p>
+        {isExcerptOverflowing && !isExcerptExpanded && (
+          <a
+            href={`/blog/posts/${slug}#excerpt-toggle`}
+            onClick={(event) => {
+              event.preventDefault();
+              setIsExcerptExpanded(true);
+            }}
+            className="absolute bottom-0 right-1 text-base leading-relaxed text-slate-100/90 underline decoration-white/40 underline-offset-2 transition-colors duration-200 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+          >
+            see more
+          </a>
+        )}
+        {isExcerptOverflowing && isExcerptExpanded && (
+          <a
+            href={`/blog/posts/${slug}#excerpt-toggle`}
+            onClick={(event) => {
+              event.preventDefault();
+              setIsExcerptExpanded(false);
+            }}
+            className="inline-block text-base leading-none text-slate-100/90 underline decoration-white/40 underline-offset-2 transition-colors duration-200 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+          >
+            show less
+          </a>
+        )}
+      </div>
     </article>
   );
 }

--- a/src/app/blog/blog-filters.tsx
+++ b/src/app/blog/blog-filters.tsx
@@ -16,6 +16,13 @@ export function BlogFilters({ searchQuery, selectedTag, tags, totalPosts }: Prop
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [query, setQuery] = useState(searchQuery ?? "");
+  const resultsLabel = [
+    `${totalPosts} article${totalPosts === 1 ? "" : "s"}`,
+    selectedTag ? `in ${selectedTag}` : "",
+    searchQuery ? `matching "${searchQuery}"` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   useEffect(() => {
     setQuery(searchQuery ?? "");
@@ -36,43 +43,48 @@ export function BlogFilters({ searchQuery, selectedTag, tags, totalPosts }: Prop
   return (
     <section className="px-4 pb-1 pt-8 md:px-8 md:pt-10">
       <form onSubmit={handleSubmit} className="mb-5">
-        <div className="mx-auto flex max-w-xl items-stretch gap-2 md:mx-0">
-          <label className="relative block h-11 min-w-0 flex-1">
-            <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-slate-500">
-              <Search size={18} strokeWidth={2} />
-            </span>
-            <input
-              type="search"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search by project, company, tool, or topic"
-              className="h-full w-full rounded-full border border-white/10 bg-slate-950/70 pl-11 pr-4 text-base text-white placeholder:text-slate-500 focus:border-fuchsia-300/50 focus:outline-none focus:ring-2 focus:ring-fuchsia-300/20"
-            />
-          </label>
-          <div className="flex h-11 shrink-0 items-stretch gap-2">
-            <PillAction
-              label={isPending ? "Searching" : "Search"}
-              onActivate={() => navigate(selectedTag, query.trim() || undefined)}
-              active={Boolean(query.trim())}
-              tone="search"
-              disabled={isPending}
-            />
-            {(selectedTag || searchQuery) && (
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-4">
+          <div className="mx-auto flex w-full max-w-xl items-stretch gap-2 md:mx-0 md:flex-1">
+            <label className="relative block h-11 min-w-0 flex-1">
+              <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-slate-500">
+                <Search size={18} strokeWidth={2} />
+              </span>
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search by project, company, tool, or topic"
+                className="h-full w-full rounded-full border border-white/10 bg-slate-950/70 pl-11 pr-4 text-base text-white placeholder:text-slate-500 focus:border-fuchsia-300/50 focus:outline-none focus:ring-2 focus:ring-fuchsia-300/20"
+              />
+            </label>
+            <div className="flex h-11 shrink-0 items-stretch gap-2">
               <PillAction
-                label="Clear"
-                onActivate={() => {
-                  setQuery("");
-                  navigate(undefined, undefined);
-                }}
-                tone="clear"
+                label={isPending ? "Searching" : "Search"}
+                onActivate={() => navigate(selectedTag, query.trim() || undefined)}
+                active={Boolean(query.trim())}
+                tone="search"
                 disabled={isPending}
               />
-            )}
+              {(selectedTag || searchQuery) && (
+                <PillAction
+                  label="Clear"
+                  onActivate={() => {
+                    setQuery("");
+                    navigate(undefined, undefined);
+                  }}
+                  tone="clear"
+                  disabled={isPending}
+                />
+              )}
+            </div>
           </div>
+          <span className="text-center text-sm text-slate-400 md:ml-auto md:whitespace-nowrap md:text-right">
+            {resultsLabel}
+          </span>
         </div>
       </form>
 
-      <div className="flex flex-wrap items-end justify-center gap-3 border-b border-white/10 pb-3 md:justify-start">
+      <div className="flex flex-wrap justify-center gap-3 border-b border-white/10 pb-3 md:justify-start">
         <TagLink href={buildBlogHref(1)} label="All" active={!selectedTag} />
         {tags.map((tag) => (
           <TagLink
@@ -82,11 +94,6 @@ export function BlogFilters({ searchQuery, selectedTag, tags, totalPosts }: Prop
             active={tag === selectedTag}
           />
         ))}
-        <span className="self-end pb-1 text-center text-sm leading-none text-slate-400 max-sm:w-full max-sm:pt-1 md:ml-auto md:text-right">
-          {totalPosts} article{totalPosts === 1 ? "" : "s"}
-          {selectedTag ? ` in ${selectedTag}` : ""}
-          {searchQuery ? ` matching "${searchQuery}"` : ""}
-        </span>
       </div>
     </section>
   );

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -19,7 +19,7 @@ export default async function Index(props: Params) {
   const page = parseInt(searchParams.page || "1", 10);
   const selectedTag = searchParams.tag?.trim() || undefined;
   const searchQuery = searchParams.q?.trim() || undefined;
-  const limit = 8;
+  const limit = 10;
   const tags = getAllTags();
   const filteredPosts = getFilteredPosts(selectedTag, searchQuery);
   const totalPosts = filteredPosts.length;


### PR DESCRIPTION
This updates the blog archive to make desktop browsing denser and cleaner.

Changes:
- Move the blog result count into the filter toolbar on desktop
- Keep tags on their own row so the count no longer wraps awkwardly with tag pills
- Switch the desktop post list to a 2-column grid at large breakpoints
- Increase blog pagination from 8 to 10 posts per page
- Change excerpts from a 3-line clamp to a 2-line clamp
- Add inline `see more` / `show less` excerpt expansion for overflowing excerpts
- Style the excerpt affordance as plain inline text instead of a button
- Tighten excerpt/toggle spacing for a cleaner card rhythm