### PR TITLE
Add Althea Science articles on autosave and session handling

### DIFF
--- a/_posts/how-i-built-a-session-timeout-warning-without-being-annoying.md
+++ b/_posts/how-i-built-a-session-timeout-warning-without-being-annoying.md
@@ -1,0 +1,210 @@
+---
+title: "A session timeout warning that doesn't get in the way"
+excerpt: "Security features get worse when they surprise people. In Generations and Reflections, I built a session monitor that warned before sign-out, let the user extend the session with a small interaction, and fixed the timer bugs that could have signed them out anyway."
+date: "2025-09-23T20:10:00.000Z"
+author:
+  name: Dmitry Jum
+  picture: "stellar/images/intro_shot.jpg"
+ogImage:
+  url: "/stellar/images/companies/ivfqc.png"
+tags: ["IVFQC", "Althea Science", "Rails", "JavaScript", "Security", "Session Management"]
+---
+
+# A session timeout warning that doesn't get in the way
+
+Forced sign-out is one of those features everybody agrees with in theory and hates in practice.
+
+You need it. You also don't want it to kick someone out while they're still working.
+
+At IVFQC, both Generations and Reflections had authenticated screens where users could spend real time entering and reviewing lab data. Letting sessions live forever wasn't a serious option. But the brute-force version of timeout handling, where the server just expires the token and the app lets the next request fail, is a bad user experience.
+
+People read that as randomness.
+
+I wanted the app to do three things well:
+
+- know when the current session would expire
+- warn the user before that happened
+- restart the timing cleanly if the user chose to keep working
+
+The first part meant the browser needed the real expiration time, not a guessed timeout hardcoded in JavaScript.
+
+## I treated expiration as server truth
+
+The monitor started by calling a lightweight endpoint:
+
+```javascript
+getCurrentExpiration: function() {
+  var promise = $.Deferred();
+  $.ajax('/auth/session-ping', {
+    type: 'GET',
+    contentType: 'application/json',
+    dataType: 'json',
+    success: function(response) {
+      promise.resolve(response.expiration_time);
+    },
+    error: function() {
+      var error = 'unable to receive token expiration time';
+      promise.reject(error);
+    }
+  });
+  return promise;
+}
+```
+
+That endpoint gave the browser a concrete expiration timestamp. Then the client built timers from that value:
+
+```javascript
+initialize: function(alertMins) {
+  this.getCurrentExpiration().done(function(res) {
+    new SessionTimers(Date.parse(res), alertMins).setTimers()
+  })
+}
+```
+
+This was important.
+
+I didn't want frontend code making up a session lifetime and hoping it matched what the auth layer believed. The server knew when the token expired. The client just needed to react to it.
+
+## The warning and the sign-out used separate timers
+
+The timer object was small on purpose:
+
+```javascript
+function SessionTimers(expirationTime, alertMins) {
+  this.exp = expirationTime
+  this.alert = alertMins
+  this.tokenTimerId;
+}
+
+SessionTimers.prototype = {
+  setTimers: function() {
+    this.alertTimer();
+    this.tokenTimer();
+  },
+
+  signOut: function() {
+    window.location = '/auth/sign-out';
+  }
+}
+```
+
+There were really two deadlines hiding inside one session:
+
+- the point where the user should be warned
+- the point where the user should be signed out
+
+The sign-out timer was straightforward:
+
+```javascript
+tokenTimer: function() {
+  var timeBeforeSignOut = this.exp - Date.now()
+  this.tokenTimerId = setTimeout(this.signOut, timeBeforeSignOut)
+}
+```
+
+The warning timer was the more interesting one:
+
+```javascript
+alertTimer: function() {
+  var timeBeforeAlert = (this.exp - (this.alert * 60 * 1000)) - Date.now()
+  setTimeout(function() {
+    $('#page-content-wrapper').prepend(SessionMonitor.warningMessage);
+    $('.session-alert').on('closed.bs.alert', {ST: this}, function (e) {
+      clearTimeout(e.data.ST.tokenTimerId);
+      SessionMonitor.initialize(e.data.ST.alert);
+    })
+  }.bind(this), timeBeforeAlert)
+}
+```
+
+The browser waited until the configured warning window, showed a dismissible alert, and then used that dismissal as a small "I'm still here" signal.
+
+No modal. No giant interruption. Just enough friction to prove the user was active.
+
+That's the whole design.
+
+## Closing the alert did more than hide the message
+
+This is where the feature got subtle.
+
+At first glance, closing the warning looks like a UI concern. It wasn't. It was really a timer-lifecycle concern.
+
+If the user closed the warning, I needed to do two things immediately:
+
+- cancel the sign-out timer based on the *old* expiration window
+- fetch current expiration again and start fresh timers
+
+If you skip the first step, you get a nasty bug. The new timer starts, but the old one is still alive in memory. Then the user gets signed out anyway when that old timeout fires.
+
+Wild bug. Also easy to miss if you only test the happy path once.
+
+That exact bug showed up later, and I fixed it in both apps by keeping the timer id and clearing it before re-initializing:
+
+```javascript
+$('.session-alert').on('closed.bs.alert', {ST: this}, function (e) {
+  clearTimeout(e.data.ST.tokenTimerId);
+  SessionMonitor.initialize(e.data.ST.alert);
+})
+```
+
+This was one of those small diffs that mattered more than a larger feature.
+
+Without it, the monitor *looked* right and still betrayed the user.
+
+## I added tests around time itself
+
+Time-based behavior gets slippery fast if you only click around manually.
+
+So I added Jasmine tests that simulated the clock and asserted the things I cared about:
+
+- initialization happens with the expected alert window
+- closing the alert re-initializes the monitor
+- the old token timer is cleared and does not sign the user out
+
+The regression test was the important one:
+
+```javascript
+it('clears old tokenTimer when alert message is closed', function() {
+  spyOn(SessionTimers.prototype, 'signOut');
+  var alertCloseSpy = spyOnEvent('.session-alert', 'closed.bs.alert');
+  $('.session-alert').trigger('closed.bs.alert');
+  jasmine.clock().tick(30000)
+  expect(SessionTimers.prototype.signOut).not.toHaveBeenCalled()
+})
+```
+
+That's the kind of test I trust.
+
+Not "it renders an alert." Not "the method was invoked." The thing I actually cared about was simpler: after the user interacted with the warning, the stale sign-out path could no longer fire.
+
+## The same pattern worked in two apps because the core problem was the same
+
+One thing I liked about this feature is that it wasn't tied to one screen or one product branch.
+
+Generations and Reflections had different DOM anchors for where the alert should appear, but the model was the same in both places:
+
+- ping for expiration
+- schedule a warning
+- schedule sign-out
+- let the user affirm activity
+- reset cleanly
+
+That made the code portable. The session monitor object and timer object stayed nearly identical across both apps, with only small UI differences around where the warning banner got inserted.
+
+That's usually a good sign. When a feature survives across products with only minor adaptation, it means the abstraction is probably about the real problem and not one page's markup.
+
+## Security work is product work
+
+I think a lot of teams still talk about security features like they're separate from user experience.
+
+They're not.
+
+If you protect a system in a way that feels arbitrary, people stop trusting the product. If you give them a little context and a predictable recovery path, the same control feels reasonable.
+
+That's what I wanted here.
+
+Don't wait for the next failed request to tell the user something expired.
+
+Tell them before it happens. Give them a small way to stay active. Make the reset logic correct. Test the timer bug that will absolutely happen if you don't.
+
+Security is part of the interface. That's the point.

--- a/_posts/how-i-fixed-a-fast-autosave-race-in-generations.md
+++ b/_posts/how-i-fixed-a-fast-autosave-race-in-generations.md
@@ -1,0 +1,173 @@
+---
+title: "Fixing a fast autosave race in Generations"
+excerpt: "Autosave gets tricky when the same field can be creating a record one moment and updating it the next. In Generations, quick edits on secondary parameters exposed that edge, so I collapsed create and update into one route and made the write path idempotent enough for rapid input."
+date: "2025-09-25T20:20:00.000Z"
+author:
+  name: Dmitry Jum
+  picture: "stellar/images/intro_shot.jpg"
+ogImage:
+  url: "/stellar/images/companies/ivfqc.png"
+tags: ["IVFQC", "Althea Science", "Rails", "JavaScript", "Autosave", "Race Conditions"]
+---
+
+# Fixing a fast autosave race in Generations
+
+Autosave bugs are rarely about one request.
+
+They're about *timing*.
+
+I ran into that in Generations while working on the procedure screens. Users could type quickly through secondary parameter fields and rely on autosave to keep up. Most of the time it did. Then the edge case showed up: a field could be in the awkward state between "this value doesn't exist yet" and "this value now exists and should be updated," and quick edits could hit both sides of that boundary too fast.
+
+That's where a clean CRUD split starts working against you.
+
+If one request is still acting like a create while the next one already assumes update semantics, the browser and server can disagree about what operation is supposed to happen.
+
+That disagreement is enough to create flaky saves.
+
+## The front end was switching forms from POST to PUT after the first save
+
+This pattern was already in the app.
+
+After a successful save, the client updated the form so the next edit would be treated as an update instead of a create:
+
+```javascript
+if (form.find('[value~=put]').length == 0 ){
+  form.prepend('<input type="hidden" name="_method" value="put">');
+}
+```
+
+That happened in `SecondaryParameterDataEntry.autoSaveDone`.
+
+The idea made sense. First request creates the record. Later requests update it.
+
+The problem was the timing window between those two states.
+
+If the user typed and autosave fired again before the UI had fully crossed that boundary, the request path could still be wrong. And because this feature lived inside a queued autosave system, that mismatch didn't always look like a clean immediate failure. It looked like a save path that was just unreliable under speed.
+
+I don't like systems that only work when the user types politely.
+
+## The fix was to stop asking the client to pick the right verb
+
+Instead of making the browser decide whether this write was a create or an update, I added a single endpoint that handled both:
+
+```ruby
+put '/zombie_procedure_values_create_or_update' => 'zombie_procedure_values#create_or_update'
+```
+
+Then I pointed the autosave form at that route:
+
+```erb
+<%= form_tag("/zombie_procedure_values_create_or_update", method: :put, remote: true,
+  class: "autosave-secondary-parameter-form", onsubmit: "return false;") do %>
+```
+
+That moved the branching logic to the server, where it belonged.
+
+The controller action looked up existing values by the parameter id and the set of completion ids. If matching rows already existed, it updated them. If not, it created them inside a transaction:
+
+```ruby
+def create_or_update
+  values = ZombieProcedureValue.where(
+    zombie_procedure_parameter_id: params[:zombie_procedure_values][:zombie_procedure_parameter_id],
+    zombie_procedure_completion_id: zombie_procedure_completion_ids
+  )
+
+  if values.present?
+    values.update_all(data: params[:zombie_procedure_values][:data].to_s)
+  else
+    ActiveRecord::Base.transaction do
+      zombie_procedure_values_params.each do |value_data|
+        ZombieProcedureValue.create(value_data)
+      end
+    end
+  end
+end
+```
+
+That wasn't a pure textbook upsert, but it was enough to remove the fragile handoff from POST to PUT in the middle of active typing.
+
+That's what I needed.
+
+## I kept the side effects in the unified path too
+
+This controller wasn't only saving a value.
+
+That particular procedure flow also had downstream behavior tied to cryopreservation events and attempt-level aggregate data. So the create-or-update action had to preserve those side effects instead of being a narrow persistence shortcut.
+
+The action recalculated the event timestamp when the saved parameter represented time:
+
+```ruby
+if ((completions.first.procedure_slug.include? "cryopreservation") &&
+    (params[:zombie_procedure_values][:parameter_slug].include? "time"))
+
+  date = params[:zombie_procedure_values][:moment_date]
+  datetime = Time.zone.parse(date + " " + params[:zombie_procedure_values][:data].to_s)
+
+  events = Event.where(event_type: 'cryopreservation',
+    zombie_id: completions.map(&:zombie_id), attempt_id: attempt_id)
+
+  events.map { |event| event.update(happened_at: datetime) }
+end
+
+BulkAttemptData.update_attempt_storage_data_for([attempt_id])
+```
+
+I mention this because it's easy to describe these fixes like they're just routing changes.
+
+They aren't.
+
+In a real Rails app with history, the write path often has product meaning attached to it. If I had "simplified" this by making a tiny alternate endpoint that only updated one table, I would've risked fixing the race and breaking the surrounding workflow.
+
+The better move was to make the write semantics more stable *without* stripping away the rest of the behavior.
+
+## The queue work made this bug visible, and also shaped the fix
+
+I don't think this race would have been as obvious without the autosave queue work that came before it.
+
+Once writes were serialized and retried more reliably, the remaining failures stood out more clearly. They stopped looking like generic flaky connectivity and started looking like operation mismatches.
+
+That distinction matters.
+
+A bad connection means "try again later."
+
+A create-vs-update race means "your write model is confused."
+
+Those are different classes of problem, and they need different fixes.
+
+The queue solved transport resilience. This controller change solved write-path ambiguity.
+
+Together they made autosave feel a lot more honest.
+
+## I also tightened the listeners around fast-changing inputs
+
+Part of this work showed up in the JavaScript listeners too.
+
+Number fields were using `keyup input`, not just `change`, so autosave would catch arrow-button changes and not miss quick edits:
+
+```javascript
+$('.main').on('keyup input','.autosave-secondary-parameter-form input[type="number"]', delayedCallback);
+```
+
+That seems small. It isn't.
+
+The browser fires different events for different kinds of interaction, and number fields are one of those places where "works when you type" is not the same as "works when you use the control normally." I made similar adjustments in other Generations autosave commits because missing events are another way to create false confidence around save behavior.
+
+If the app is going to save in the background, it needs to notice what the user actually did.
+
+## Good autosave work reduces the number of states the client can get wrong
+
+That's the real lesson from this fix.
+
+When a user is moving quickly, every extra client-side state transition is another place for timing bugs to hide. "This form is now a create." "Now it is an update." "Now the hidden method changed." "Now the route changed." That stack can work, but it gives you a lot of edges to defend.
+
+The create-or-update endpoint removed one of those edges.
+
+The browser no longer had to be perfectly synchronized with record existence in order to send a valid write.
+
+I like that kind of fix because it doesn't just patch the symptom. It makes the system less sensitive to timing in the first place.
+
+That's what autosave needs.
+
+Not just speed.
+
+Fewer ways to be wrong.

--- a/_posts/how-i-kept-ivf-data-safe-during-bad-connections.md
+++ b/_posts/how-i-kept-ivf-data-safe-during-bad-connections.md
@@ -1,0 +1,213 @@
+---
+title: "Keeping IVF data safe during bad connections"
+excerpt: "An autosave feature is easy to pitch and easy to get wrong. The real work was making sure form writes survived unstable internet, page reloads, and rapid-fire input across a Rails app full of live data entry."
+date: "2025-09-24T20:00:00.000Z"
+author:
+  name: Dmitry Jum
+  picture: "stellar/images/intro_shot.jpg"
+ogImage:
+  url: "/stellar/images/companies/ivfqc.png"
+tags: ["IVFQC", "Althea Science", "Rails", "JavaScript", "Autosave", "LocalStorage"]
+---
+
+# Keeping IVF data safe during bad connections
+
+The easiest way to lose trust in a lab app is to lose someone's data.
+
+That sounds obvious, but it's the kind of problem that hides in plain sight when a product mostly works on office Wi-Fi and a developer laptop.
+
+At IVFQC, both Generations and Reflections had screens where people were entering operational data quickly, field after field, often without pausing to think about whether a network request had finished. That's normal behavior. Nobody wants to stop and wait for a spinner while moving through a workflow.
+
+Here's the problem: the old version of autosave depended too much on the request that had *just* been fired. If the connection dropped, if the request timed out, or if the page refreshed at the wrong moment, you could end up with values that the user thought were saved but never made it to the server.
+
+I didn't want "autosave" to mean "we tried."
+
+I wanted it to mean the browser kept enough intent around to finish the write later.
+
+## The browser needed a write-ahead log
+
+The core idea was simple.
+
+Every autosave action had to become a small request object. That object needed to be persisted before the network got a chance to fail. LocalStorage was good enough for that job.
+
+The queue object handled the storage side:
+
+```javascript
+RequestQueue = {
+  requests: function(queueType) {
+    if(queueType == undefined) throw new Error("Missing an argument, queueType string is required")
+    if (localStorage['queues']) {
+      return JSON.parse(localStorage.queues)[queueType] != undefined ?
+       localStorage.getObject('queues')[queueType] :
+        localStorage.setObject('queues', Object.assign({[queueType]: []}, localStorage.getObject('queues')))[queueType]
+    } else {
+      return localStorage.setObject('queues', {[queueType]: []})[queueType];
+    };
+  },
+
+  enque: function(queueType, request) {
+    var updatedQueue = this.requests(queueType).concat([request])
+    localStorage.setObject('queues', {[queueType]: updatedQueue})
+    PubSub.emit(REQUEST_ENQUEUED, queueType);
+  }
+}
+```
+
+That lived in the Reflections app, and the Generations version used the same shape with jQuery events instead of the small PubSub helper.
+
+I like this because it turns the problem into something concrete. Don't argue about connectivity. Serialize the user's intended write and keep it somewhere durable in the browser.
+
+That changed the contract.
+
+The request wasn't "gone" just because the server didn't answer right away.
+
+## Autosave became a queue consumer, not a click side effect
+
+Once requests were durable, the next step was to make the save layer process them in order.
+
+That logic lived in `DataEntryHandler`:
+
+```javascript
+autoSaveQueue: function() {
+  RequestQueue.requests('autoSaveQueue').slice(0,1).forEach(function(params) {
+    params = Object.assign({
+      dataType: 'json',
+      beforeSend: beforeSendCb,
+      success: successCb,
+      error: errorCb
+    }, params);
+
+    $.ajax(params)
+  })
+}
+```
+
+It only pulled the first item from the queue. That's the point.
+
+I didn't want a burst of keystrokes to create a burst of overlapping writes that raced each other to the server. I wanted one request in flight, then the next, then the next. If a save succeeded, the handler removed the first item and immediately tried the next one. If a save failed with a connectivity issue, the item stayed in the queue and the handler retried a few seconds later.
+
+That gave the system two useful properties:
+
+- writes stayed ordered
+- failures became recoverable instead of silent
+
+Those two things matter more than a fancy autosave badge.
+
+## I moved the queue boundary up into shared form logic
+
+The queue only works if every entry point uses it.
+
+Both apps had enough different data-entry surfaces that I didn't want each one reinventing save behavior. In Generations I started pushing common behavior into a parent object that all those entry flows could call.
+
+The shared method looked like this:
+
+```javascript
+autoSave: function(item, queueType, inputCompoundId) {
+  var entry_form = item.closest('form');
+  var type = entry_form.attr('method');
+  if (entry_form.find('input[name="_method"]').length > 0) {
+    type = entry_form.find('input[name="_method"]').val()
+  }
+  $('body').triggerHandler(AUTOSAVE, {
+    queueType: queueType,
+    request: {
+      type: type,
+      url: entry_form.attr('action'),
+      data: entry_form.serialize(),
+      inputCompoundId: inputCompoundId
+    }
+  })
+}
+```
+
+What I like here is that the form code stopped caring about retry logic.
+
+The feature-specific listener only had to answer a few questions:
+
+- which form is this input part of
+- what queue should handle it
+- how long should the debounce be
+
+Everything after that went through the same path.
+
+That made the queue reusable across global data entry, zombie procedures, droplet inputs, and secondary parameters. Different screens. Same behavior.
+
+## The UX had to admit when the internet disappeared
+
+I didn't want the app to quietly pile up writes and pretend nothing was wrong.
+
+If the connection dropped, the screen needed to say so. If it came back and the queue resumed, the screen needed to say that too.
+
+The retry path handled that:
+
+```javascript
+if (status === 'timeout' || status === "error") {
+  var internetWarning = '<div class="alert alert-info internet-response">' +
+   'Connection lost. Data will save when reconnected.' +
+  '</div>'
+
+  if ($('.main').find('.internet-response').length > 0) {
+    $('.internet-response').replaceWith(internetWarning);
+  } else {
+    $('.main').find('.card').first().before(internetWarning);
+  }
+
+  setTimeout(function() {
+    if (RequestQueue.requests(this.queueType).length > 0) DataEntryHandler.autoSave(this.queueType)
+  }.bind(this), 3000)
+}
+```
+
+That wasn't dramatic UI work. It was operational honesty.
+
+Users could keep entering data and know what was happening. When the page loaded again later, `completeAllQueues()` checked localStorage, resumed any unfinished work, and showed a message that the earlier connectivity issue seemed to be resolved.
+
+That's the part I still like most. The browser remembered unfinished intent and the app had the manners to explain itself.
+
+## Some failures should retry. Some should get out of the way
+
+One detail from the Generations version mattered a lot.
+
+Not every failed request should stay in the queue forever.
+
+There were cases where the server returned `422 Unprocessable Entity`, not because the connection was bad, but because the requested change itself was invalid. One example in the code comments was decreasing the number of oocytes when the business rules no longer allowed it.
+
+For that case, I explicitly removed the failing request from the queue:
+
+```javascript
+if (error === "Unprocessable Entity") {
+  RequestQueue.spliceRequests(this.queueType, 0, 1);
+  if($('.autosave-status').length > 0) $('.autosave-status').html('- Failed.');
+  return;
+};
+```
+
+That's a small branch, but it's the difference between a resilient queue and a zombie queue.
+
+Retry transport failures.
+
+Don't retry validation failures forever.
+
+## I tested the boring parts because those were the product
+
+This work wasn't the kind of thing you validate with one happy-path integration test and call finished.
+
+I added JavaScript specs around the mechanics that actually mattered:
+
+- creating missing queue buckets in localStorage
+- appending requests in order
+- splicing requests after success
+- emitting queue events
+- resuming outstanding queues after reload
+
+That mattered because the product promise wasn't "there is autosave code in the repo."
+
+The promise was stronger than that. If the user typed, the app kept trying until the write either succeeded or failed for a real business reason.
+
+That's not glamorous work.
+
+It's still some of my favorite work.
+
+When software deals with health workflows, "probably saved" isn't good enough. You want a system that assumes the network will disappoint you and plans around it.
+
+That's all.


### PR DESCRIPTION
Adds three new blog posts based on my work on the Generations and Reflections Rails apps at Althea Science / IVFQC. The posts cover the LocalStorage-backed autosave queue for unreliable connections, the session timeout warning flow across both apps, and the fix for a fast autosave race in Generations.