### PR TITLE
Add three AlumniFire engineering retrospectives

### DIFF
--- a/_posts/alumnifire.md
+++ b/_posts/alumnifire.md
@@ -7,7 +7,7 @@ author:
   picture: "stellar/images/intro_shot.jpg"
 ogImage:
   url: "/assets/blog/alumnifire/alumnifire.png"
-tags: ["alumnifire"]
+tags: ["AlumniFire", "Rails", "Ruby"]
 ---
 
 AlumniFire is a specialized networking platform that enables alumni to create opportunities for one another on their own terms. The platform connects graduates, facilitating meaningful professional relationships and career advancement.

--- a/_posts/building-an-internship-search-that-remembered-what-you-wanted.md
+++ b/_posts/building-an-internship-search-that-remembered-what-you-wanted.md
@@ -1,0 +1,183 @@
+---
+title: "How I built an internship search that remembered what you wanted"
+excerpt: "An internship search shouldn't force students to rebuild the same filters every time they come back. I built the flow so criteria persisted, geolocation stayed queryable, and search results could turn directly into resume drops."
+date: "2025-09-29T18:30:00.000Z"
+author:
+  name: Dmitry Jum
+  picture: "stellar/images/intro_shot.jpg"
+ogImage:
+  url: "/assets/blog/alumnifire/alumnifire.png"
+tags: ["AlumniFire", "Rails", "Geocoder", "Search", "Product"]
+---
+
+# How I built an internship search that remembered what you wanted
+
+Search gets worse fast when the app forgets your intent.
+
+That was especially true for internship outreach at AlumniFire in 2015. A student wasn't just browsing profiles. They were trying to answer a practical question: who should get my resume, based on industry and location, and how do I avoid repeating work I've already done?
+
+I wanted that flow to feel less like a stateless filter form and more like a saved work session.
+
+Some of the implementation is visibly 2015 Rails code. That's expected. What still matters is the product logic: persist the search, preserve intent, and let the result set turn into actual outreach.
+
+## I persisted the search, not just the results
+
+The controller didn't throw the criteria away after the first request. It saved an `InternshipSearch` and attached criterion records to it:
+
+```ruby
+@internship_search = current_profile.internship_searches.create(
+  fullfilled: false,
+  search_criteria: [
+    InternshipSearchCriterion.create(industry_criterion_params),
+    InternshipSearchCriterion.create(location_criterion_params)
+  ])
+```
+
+That let the feature do something more useful than "show me matches right now."
+
+It could also say:
+
+- show me the unfinished search I was working on
+- show me the employers tied to that search
+- show me which resume drops came from it later
+
+That's a much better product loop.
+
+## The unfinished search became the default
+
+When a user came back, the app looked for their last unfulfilled search first:
+
+```ruby
+last_unfullfilled = current_profile.internship_searches.find_by fullfilled: false
+@internship_search = last_unfullfilled.present? ? last_unfullfilled : current_profile.internship_searches.new
+```
+
+I like this because it respects the user's time.
+
+If they already picked industries and locations, they shouldn't have to rebuild that state from scratch just because they closed the page or got interrupted. The app already knows what they were trying to do. It should act like it.
+
+That same persisted object also drove the history screen, where completed searches and one-off resume drops were merged into a single timeline:
+
+```ruby
+individual_drops = current_profile.requests.where(type: 'ResumeDrop', internship_search_id: nil)
+searches = current_profile.internship_searches.where(fullfilled: true)
+@search_and_drops = (individual_drops + searches).sort {|x,y| y.updated_at <=> x.updated_at}
+```
+
+That's not just storage. That's workflow.
+
+## I kept the criteria flexible on purpose
+
+The criterion model was simple:
+
+```ruby
+class InternshipSearchCriterion < ActiveRecord::Base
+  self.table_name = 'internship_search_criteria'
+  self.inheritance_column = nil
+
+  belongs_to :internship_search
+  serialize :value, Hash
+end
+```
+
+The search needed heterogeneous criteria. Industry looked different from location. Location also carried a radius. In 2015, a serialized hash gave me enough structure to move fast without inventing a new table design for every filter type.
+
+That kept the search object extensible.
+
+## The hard part was geolocation
+
+The interesting search logic lived in the model:
+
+```ruby
+near_queries = location.value[:name].map do |city|
+  User.where('location IS NOT NULL').near(city, location.value[:range] || 10).to_sql
+end
+```
+
+Then those SQL fragments got folded back into profile queries:
+
+```ruby
+Profile.seeking_interns.for_school(seeker.school).where(users: {industry: industries})
+  .where("users.id IN (SELECT id FROM (#{q}) AS sub)")
+```
+
+The geocoder gem had a bug at that time that made the direct relation hard to merge cleanly once joins got involved, so I translated the proximity result into SQL and used that as a boundary.
+
+Don't keep arguing with an abstraction after it stops helping. If the relation composition is broken, drop down a level, extract the SQL you need, and keep the product moving.
+
+## I filtered out employers the student had already contacted
+
+Search results aren't useful if half the list is work you've already done.
+
+So before paginating the matches, I rejected existing recipients:
+
+```ruby
+def new_employers_from(search)
+  existing_recipient_ids = current_profile.requests.where(type: 'ResumeDrop').pluck(:recipient_id)
+
+  search.reject do |p|
+    existing_recipient_ids.include? p.id
+  end
+end
+```
+
+This is simple code doing a high-value thing.
+
+A lot of product friction comes from making users mentally diff the current screen against their past actions. I prefer when the system does that bookkeeping itself.
+
+If a student already sent a resume to someone, the search shouldn't ask them to notice that manually.
+
+## The endpoint could turn matches straight into outreach
+
+The last step was the part I liked most.
+
+The search wasn't just a list. It could become a batch of resume drops:
+
+```ruby
+new_employers_from(@search).each do |p|
+  params[:resume_drop][:recipient_id] = p.id
+  @request = @internship_search.resume_drops.new request_params
+
+  service = RequestService.new @request
+  service.save!
+  service.activate!
+  @internship_search.update(fullfilled: true) unless @internship_search.fullfilled
+end
+```
+
+That collapsed a lot of repetitive work.
+
+Pick the criteria. Review the matching employers. Attach the resume. Send the outreach. The search object then stayed behind as the record of what happened and how many results it produced.
+
+That's a decent example of a feature growing up from "find things" into "help me finish the job."
+
+## I added guardrails for the edges
+
+There were a couple of failure cases I didn't want to ignore.
+
+If the user tried to search without a location, the app pushed them back to the form with a clear message. If the `drop_resume` action ran after the unfinished search had disappeared, it returned the user to the new-search path instead of blowing up:
+
+```ruby
+if @internship_search.nil?
+  flash[:warning] = 'Please input a search before sending resumes.'
+  render 'redirect_to_new', layout: false and return
+end
+```
+
+Those checks aren't flashy, but they're the difference between a feature that demos well and a feature that survives real users.
+
+## I still like the shape of this
+
+What I like most is that the feature kept state in the backend where the workflow already lived.
+
+The student had a search object.
+That search had typed criteria.
+That search could produce filtered employers.
+That search could own resume drops.
+That search could later show up in history.
+
+That's a clean product model.
+
+Plenty of search features stop at matching.
+
+This one remembered what the user wanted and carried that intent all the way through outreach. That's better.

--- a/_posts/cutting-a-rails-analytics-dashboard-from-10-seconds-to-2.md
+++ b/_posts/cutting-a-rails-analytics-dashboard-from-10-seconds-to-2.md
@@ -1,0 +1,192 @@
+---
+title: "How I cut a Rails analytics dashboard from 10 seconds to 2"
+excerpt: "A slow admin dashboard usually means someone hid network latency inside a nice-looking graph. I sped up an old Rails dashboard by parallelizing Google Analytics queries and caching time-bucketed results."
+date: "2025-09-30T18:15:00.000Z"
+author:
+  name: Dmitry Jum
+  picture: "stellar/images/intro_shot.jpg"
+ogImage:
+  url: "/assets/blog/alumnifire/alumnifire.png"
+tags: ["AlumniFire", "Rails", "Google Analytics", "Performance", "Caching"]
+---
+
+# How I cut a Rails analytics dashboard from 10 seconds to 2
+
+Admin dashboards lie all the time.
+
+They look like simple tables and charts, but the real product is waiting. Waiting on external APIs, waiting on aggregation code, waiting on one more query that someone assumes is cheap because it only runs for staff.
+
+At AlumniFire, in 2015, I worked on a reporting dashboard that pulled product signals out of Google Analytics. It showed pageviews, events, signups, and other engagement slices across time windows like today, yesterday, this week, and this month.
+
+The first version worked.
+
+It was also slow enough to be annoying.
+
+Some of the code in this post is obviously from that era. That's fine. I'm not holding it up as a modern analytics stack. The useful part is the performance problem and the way I solved it inside the Rails app we had at the time.
+
+## The bottleneck wasn't Rails
+
+The expensive part lived in the analytics collector:
+
+```ruby
+def get_pageviews_hash
+  pageviews_filter_types.keys.each {|t| @pageviews_hash[t] = Hash.new}
+  clear_old_keys __method__
+  Rails.cache.fetch(cache_key __method__) do
+    period_columns.keys.pmap do |c|
+      c == "_all_time" ? pageview_query("2014-01-01", c) : pageview_query(period_columns[c], c)
+    end
+    set_possible_newuser_info
+    @pageviews_hash
+  end
+end
+```
+
+That method was doing the right business work. It wasn't doing it in the cheapest way.
+
+The dashboard wanted the same metrics across multiple time ranges. Each range meant another request to Google Analytics. Once you stack pageviews and event queries on top of that, a page load can quietly turn into a small pile of remote calls.
+
+That's why the page felt slow even though the Rails app itself wasn't under much pressure.
+
+## I parallelized the time slices
+
+The main improvement was embarrassingly straightforward.
+
+Instead of querying each date range one after another, I spread the work across threads:
+
+```ruby
+module Enumerable
+  def pmap(cores = 4, &block)
+    [].tap do |result|
+      each_slice((count.to_f/cores).ceil).map do |slice|
+        Thread.new(result) do |result|
+          slice.each do |item|
+            result << block.call(item)
+          end
+        end
+      end.map(&:join)
+    end
+  end
+end
+```
+
+Then the dashboard used that helper over the period keys:
+
+```ruby
+period_columns.keys.pmap do |c|
+  c == "_all_time" ? event_query("2014-01-01", c) : event_query(period_columns[c], c)
+end
+```
+
+That cut the query time from roughly 8 to 10 seconds down to about 2 to 4 seconds. Not because the logic changed, but because the waiting overlapped instead of stacking.
+
+That's a useful lesson in old Rails apps.
+
+If the slowness is remote I/O, don't spend all day shaving Ruby objects before you fix the call pattern.
+
+## I kept the result shape stable
+
+I wasn't trying to redesign the admin page. I just wanted it to answer faster.
+
+So the data structure stayed boring:
+
+```ruby
+def pageview_query(date, c)
+  return_vals = params(date, 'ga:pagePath', 'ga:pageviews', requested_pages)
+  pageviews_filter_types.keys.each {|t| @pageviews_hash[t][c] = return_vals[pageviews_filter_types[t]].to_i}
+end
+```
+
+And the event side matched it:
+
+```ruby
+def event_query(date, c)
+  return_vals = params(date, 'ga:eventAction', 'ga:totalEvents', requested_events)
+  event_filter_types.each {|t| @events_hash[t][c] = return_vals[t].to_i}
+end
+```
+
+That mattered.
+
+If you're speeding up a reporting surface that people already use, preserving the result contract buys you safety. The view code doesn't need to care that the fetch strategy changed. It still gets the same hashes, keyed the same way.
+
+Fast is good. Predictable fast is better.
+
+## Then I stopped recomputing the same answer
+
+Parallel requests helped, but it still didn't make sense to ask Google Analytics the same question on every dashboard load.
+
+So I added a cache key tied to rounded time:
+
+```ruby
+def cache_key(method_name)
+  "#{method_name}_#{RoundedTime.floor(5.minutes)}"
+end
+```
+
+The helper behind that was tiny:
+
+```ruby
+class RoundedTime
+  def self.floor(seconds = 60)
+    Time.at((Time.now.to_f / seconds).floor * seconds)
+  end
+end
+```
+
+That gave me a practical compromise.
+
+The dashboard didn't need second-by-second freshness. Five-minute buckets were plenty for an admin view. So instead of arguing about "real-time analytics," I picked a freshness window that matched how the page was actually used.
+
+That turned a recurring remote workload into a periodic one.
+
+## Cache cleanup mattered too
+
+One detail I still appreciate is that I didn't just add cache entries and walk away:
+
+```ruby
+def clear_old_keys(method_name)
+  cache_keys = Rails.cache.instance_variable_get(:@data).keys
+  cache_keys.grep(/#{method_name}/).each do |key|
+    Rails.cache.delete(key) if key != cache_key(method_name)
+  end
+end
+```
+
+I wouldn't reach into the cache internals like that in a modern app unless I had to, but the intent was right.
+
+If the key rotates every five minutes, old buckets should stop piling up. Otherwise the speed fix slowly turns into a storage leak with better branding.
+
+That's the kind of maintenance detail people skip when they're excited that the page finally feels quick.
+
+I didn't want a temporary win.
+
+## The data model for time windows stayed simple
+
+The period helper was also deliberately plain:
+
+```ruby
+def period_columns
+  {"_all_time" => nil, "_today" => Time.zone.now.to_date, "_yesterday" => 1.day.ago.to_date,
+   "_two_days_ago" => 2.day.ago.to_date, "_three_days_ago" => 3.day.ago.to_date,
+    "_this_week" => 7.days.ago.to_date, "_this_month" => 1.month.ago.to_date}
+end
+```
+
+That made the collector easy to reason about.
+
+Every metric constructor spoke the same time language. If the admin UI wanted to add a row or graph, the periods were already standardized.
+
+I like code that turns reporting into a reusable pattern instead of a pile of special cases.
+
+## The best part was that it stayed boring to use
+
+Staff didn't need to know the dashboard was now doing threaded API calls.
+
+They just clicked the page and it stopped wasting their time.
+
+That's the version of performance work I enjoy most. Not synthetic benchmarks. Not heroic rewrites. Just finding the real wait, overlapping the expensive work, and caching at a boundary the user will never notice.
+
+The dashboard still asked the same questions.
+
+It just stopped asking them so slowly.

--- a/_posts/the-school-quiz-that-doubled-as-an-onboarding-funnel.md
+++ b/_posts/the-school-quiz-that-doubled-as-an-onboarding-funnel.md
@@ -1,0 +1,257 @@
+---
+title: "The school quiz that doubled as an onboarding funnel"
+excerpt: "At AlumniFire, the quiz wasn't just trivia. It was a school-specific scoring flow that fed sharing, reminder emails, and signup attribution without breaking the subdomain model."
+date: "2025-10-01T19:15:00.000Z"
+author:
+  name: Dmitry Jum
+  picture: "stellar/images/intro_shot.jpg"
+ogImage:
+  url: "/assets/blog/alumnifire/alumnifire.png"
+tags: ["AlumniFire", "Rails", "Product", "Quiz", "Growth"]
+---
+
+# The school quiz that doubled as an onboarding funnel
+
+Trivia features are easy to underestimate.
+
+At AlumniFire, in 2015, the quiz wasn't there to keep people busy for thirty seconds. It was there to make a school network feel real before someone even joined it.
+
+That mattered because AlumniFire wasn't a generic social site. Each school had its own subdomain, its own network, and its own identity. So a school-knowledge quiz did two jobs at once:
+
+- it gave people something school-specific to engage with
+- it pulled them toward signup without feeling like a signup wall
+
+Pretty good shape for a small feature.
+
+The code around it has some very 2015 Rails habits. That's part of the context here. I'm not trying to pretend the implementation is brand new. I'm interested in the quiz logic and the product loop it supported.
+
+## The quiz was scoped to the current school from the start
+
+The controller only exposed active quizzes for the current school:
+
+```ruby
+def index
+  @quizzes = current_school.quizzes.active
+  redirect_to start_quiz_path(@quizzes.first) if @quizzes.count == 1
+end
+```
+
+And it also guarded against school mismatches:
+
+```ruby
+def require_correct_school
+  if current_school.blank? || quiz_school_mismatch
+    redirect_to root_path
+  end
+end
+
+def quiz_school_mismatch
+  @quiz && @quiz.school != current_school
+end
+```
+
+I like this because it kept the feature aligned with the actual product model.
+
+This wasn't one giant public quiz catalog. A Columbia quiz belonged on Columbia's subdomain. A different school got a different quiz, different branding, different outcomes, and eventually a different signup funnel.
+
+That's the right call when the network boundary is the school.
+
+## Questions were weighted, not just counted
+
+The scoring system didn't treat every question as worth the same amount. Each question had a `value`, and the score engine used that directly:
+
+```ruby
+def radio
+  if submitted_answer_id.present?
+    Answer.find(submitted_answer_id).correct ? submitted_question.value : 0
+  elsif no_correct_answers?
+    submitted_question.value
+  else
+    0
+  end
+end
+```
+
+That let the content team decide which questions were lightweight and which ones mattered more.
+
+A generic quiz app usually counts raw correct answers. This one had room for editorial weighting. That's a better fit when the quiz is about school identity and not just random entertainment.
+
+## Checkbox questions got partial credit in a way I still like
+
+The more interesting logic was the checkbox path:
+
+```ruby
+def checkbox
+  user_answers = Answer.where(id: submitted_answer_ids)
+  user_correct_answers = user_answers.select {|a| a.correct}
+  user_correct_non_answers = submitted_question.answers.where.not(id: user_answers.map(&:id), correct: true)
+  one_answer_value = (submitted_question.value.to_f / submitted_question.answers.count.to_f).round(2)
+  user_question_score = (user_correct_answers.count + user_correct_non_answers.count) * one_answer_value
+end
+```
+
+Here's what that means in practice.
+
+The question value gets split evenly across all available answers. Then the user earns points for two kinds of correctness:
+
+- selecting answers that are actually correct
+- leaving incorrect answers unselected
+
+That's more interesting than a pass/fail checkbox question.
+
+It means the quiz isn't only measuring whether someone spotted the right choices. It's also measuring whether they avoided the wrong ones. For a school-knowledge quiz, that feels fair. It rewards actual recognition instead of lucky over-clicking.
+
+## The UI moved one question at a time, but the score stayed cumulative
+
+The quiz view was intentionally simple:
+
+```haml
+= form_tag submit_answer_quizzes_path(last_question: @current_question.id, total_score: @total_score), remote: true do
+  .panel.panel-default
+    .panel-heading
+      .panel-title= @current_question.header
+```
+
+Each submit carried two things forward:
+
+- the last question id
+- the running total score
+
+The controller picked up the submitted question, found the next one by position, and updated the total:
+
+```ruby
+@submitted_question = Question.find(params[:last_question])
+@quiz = Quiz.find(@submitted_question.quiz_id)
+@questions = @quiz.questions.order(position: :asc)
+@current_question = @questions[@questions.index(@submitted_question) + 1]
+
+logic = QuizLogic.new({
+  submitted_question: @submitted_question,
+  answer: params[:answer],
+  answer_ids: params[:answer_ids]
+})
+
+@total_score = params[:total_score].to_i + logic.get_current_score
+```
+
+Then the frontend swapped the panel with JS:
+
+```javascript
+$("#quiz-view").empty();
+$("#quiz-view").html("<%= j render 'question' %>");
+```
+
+I like this structure because it kept the interaction lightweight without turning the whole feature into a client-side app. Rails still owned the sequence, the question order, and the scoring logic. The browser just moved the user through the flow.
+
+That's a practical split.
+
+## The result screen was designed to keep the loop going
+
+Once the quiz ended, the app stored a `QuizScore`, calculated the percentage against the total weighted value of the quiz, and generated share copy:
+
+```ruby
+def self.score_percent(score, quiz)
+  score / (quiz.questions.pluck(:value).reduce(:+).to_f) * 100
+end
+
+def self.score_title(score_percent, school)
+  "My score... #{score_percent.round}% on the #{school.informal_name} quiz"
+end
+```
+
+The score page then did three useful things:
+
+- showed the user's result
+- offered Facebook sharing
+- pushed the user toward signup
+
+It also had a nice little hook: if someone entered their email address, the app would send a reminder showing the average score for that quiz.
+
+```ruby
+@average_score = @quiz.quiz_scores.average(:score).to_f
+@average_percent = QuizLogic.score_percent(@average_score, @quiz).to_i
+```
+
+That's better than a dead-end result screen.
+
+Instead of "thanks, you're done," the feature became "here's your score, here's how other people do, and here's the next step if you want access to the actual community."
+
+## The reminder email and signup path preserved attribution
+
+The reminder flow was pretty direct:
+
+```ruby
+@email = SignUpReminderEmail.create(reminder_email_params)
+UserMailer.signup_reminder_email(@email.id, current_school.id).deliver
+```
+
+And the email linked back into the school with quiz context:
+
+```haml
+#{link_to 'Sign Up', root_url(subdomain: current_school.subdomain, quiz: true)}
+```
+
+From there the app recorded that the user came from a quiz.
+
+The school page stashed that in the session:
+
+```ruby
+def check_if_came_from_quiz
+  if params[:from_quiz].present? && current_school.present?
+    session[:from_quiz] = true
+  end
+end
+```
+
+Then account creation copied it onto the user:
+
+```ruby
+def determine_if_user_came_from_quiz
+  params[:user][:from_quiz] = session[:from_quiz]
+end
+```
+
+That's the part I like most.
+
+The quiz wasn't just engagement bait. It was wired into attribution cleanly enough that the admin side could measure what happened next.
+
+## The admin panel tracked whether the funnel worked
+
+The reporting object for quizzes tracked more than completions:
+
+```ruby
+def get_profiles_from_quizzes_hash
+  profiles_from_quizzes = Profile.joins(:user).where(users: {from_quiz: true}).uniq
+  @profiles_from_quizzes_hash["_all_time"] = profiles_from_quizzes.count
+  get_single_data_hash({
+    all_time_klass: profiles_from_quizzes,
+    hash: @profiles_from_quizzes_hash
+  })
+end
+```
+
+There was a matching method for validated profiles too.
+
+That closed the loop:
+
+- people take the quiz
+- some ask for the reminder email
+- some click through to signup
+- some finish registration
+- some get validated into the network
+
+That's a full product funnel, not just a scoring toy.
+
+## I still like the logic here
+
+The best part of this feature is that it respected the product.
+
+It was school-specific.
+It had weighted questions.
+It handled radio and checkbox scoring differently.
+It stayed server-driven.
+It turned quiz completions into measurable signup intent.
+
+A lot of quiz features stop at "you got 8 out of 10."
+
+This one was trying to turn school familiarity into community entry. That's more interesting.


### PR DESCRIPTION
This PR adds three new blog posts based on my 2015 work on AlumniFire:

- internship search and resume-drop workflow
- analytics dashboard performance work
- school quiz logic and onboarding funnel

Each post is written as a technical retrospective, with explicit 2015 context so older implementation patterns read as period-specific tradeoffs rather than current recommendations.

## Posts added

- `_posts/building-an-internship-search-that-remembered-what-you-wanted.md`
- `_posts/cutting-a-rails-analytics-dashboard-from-10-seconds-to-2.md`
- `_posts/the-school-quiz-that-doubled-as-an-onboarding-funnel.md`